### PR TITLE
develop

### DIFF
--- a/mychro.sh
+++ b/mychro.sh
@@ -15,4 +15,5 @@ chromium --remote-debugging-port=9223 \
          --disable-gpu \
          --no-sandbox \
          --disable-setuid-sandbox \
+         --password-store=basic \
          --user-data-dir=/tmp/chrome-profile


### PR DESCRIPTION
- **Add Puppeteer development environment with noVNC and supervisord**
  - Add Dockerfile for Debian-based Puppeteer dev environment
  - Add supervisord configuration for process management (Chromium + socat)
  - Add mychro.sh for Chromium startup with remote debugging
  - Add start-supervised.sh as container entrypoint
  - Add README with setup instructions
  - Add .gitignore for common excludes
  
  Chromium auto-starts on container launch and is viewable via noVNC (port 6080).
  Remote debugging available on port 9222.
  
  🤖 Generated with [Claude Code](https://claude.com/claude-code)
  
  Co-Authored-By: Claude <noreply@anthropic.com>
  

- **Fix: Ensure Chromium uses basic password store in mychro.sh**
  