### PR TITLE
develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,23 @@ supervisorctl -c /etc/supervisor/conf.d/app.conf restart chromium
 - Chromium: `/tmp/chromium-stdout.log`, `/tmp/chromium-stderr.log`
 - Socat: `/tmp/socat-stdout.log`, `/tmp/socat-stderr.log`
 - Supervisord: `/tmp/supervisord.log`
+
+## Example Usage(Not implemented)
+
+### Running from the terminal
+
+Set the `DISPLAY` environment variable to use the VNC server:
+
+```sh
+DISPLAY=:1 node example.mjs
+```
+
+You can watch the browser in action via noVNC at http://localhost:6080/
+
+### Using xvfb
+
+Use `xvfb-run` to run headful mode without a display (useful for CI/CD):
+
+```sh
+xvfb-run --auto-servernum npx node example.mjs
+```


### PR DESCRIPTION
- **Add Puppeteer development environment with noVNC and supervisord**
  - Add Dockerfile for Debian-based Puppeteer dev environment
  - Add supervisord configuration for process management (Chromium + socat)
  - Add mychro.sh for Chromium startup with remote debugging
  - Add start-supervised.sh as container entrypoint
  - Add README with setup instructions
  - Add .gitignore for common excludes
  
  Chromium auto-starts on container launch and is viewable via noVNC (port 6080).
  Remote debugging available on port 9222.
  
  🤖 Generated with [Claude Code](https://claude.com/claude-code)
  
  Co-Authored-By: Claude <noreply@anthropic.com>
  

- **Fix: Ensure Chromium uses basic password store in mychro.sh**
  

- **Add example usage section to README for running Chromium with noVNC**
  