### PR TITLE
develop

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -67,7 +67,7 @@
 #
 
 # Debian 12.13
-FROM debian:bookworm-20260202
+FROM debian:bookworm-20260316
 
 ARG user_name=developer
 ARG user_id

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -94,11 +94,11 @@ ENV TZ="$TZ"
 # Git
 #
 RUN apt-get update -qq && \
-  apt-get install -y -qq --no-install-recommends \
-    ca-certificates \
-    git && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/*
+    apt-get install -y -qq --no-install-recommends \
+        ca-certificates \
+        git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 #
 # clone features
@@ -115,15 +115,15 @@ RUN cd /usr/src && \
 #   https://github.com/uraitakahito/features/blob/deb6cf416fda206b99c7b771e9caa12e6952f9c7/src/common-utils/main.sh#L35-L78
 #
 RUN USERNAME=${user_name} \
-  USERUID=${user_id} \
-  USERGID=${group_id} \
-  CONFIGUREZSHASDEFAULTSHELL=true \
-  UPGRADEPACKAGES=false \
-  # When using ssh-agent inside Docker, add the user to the root group
-  # to ensure permission to access the mounted socket.
-  #   https://github.com/uraitakahito/features/blob/59e8acea74ff0accd5c2c6f98ede1191a9e3b2aa/src/common-utils/main.sh#L467-L471
-  ADDUSERTOROOTGROUP=true \
-    /usr/src/features/src/common-utils/install.sh
+    USERUID=${user_id} \
+    USERGID=${group_id} \
+    CONFIGUREZSHASDEFAULTSHELL=true \
+    UPGRADEPACKAGES=false \
+    # When using ssh-agent inside Docker, add the user to the root group
+    # to ensure permission to access the mounted socket.
+    #   https://github.com/uraitakahito/features/blob/59e8acea74ff0accd5c2c6f98ede1191a9e3b2aa/src/common-utils/main.sh#L467-L471
+    ADDUSERTOROOTGROUP=true \
+        /usr/src/features/src/common-utils/install.sh
 
 #
 # Install extra utils.
@@ -149,13 +149,13 @@ RUN cd /usr/src && \
 # https://zenn.dev/tom1111/articles/0dc7cde5c8e9bf
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      chromium \
-      chromium-sandbox \
-      fonts-ipafont-gothic \
-      fonts-wqy-zenhei \
-      fonts-thai-tlwg \
-      fonts-kacst \
-      fonts-freefont-ttf && \
+        chromium \
+        chromium-sandbox \
+        fonts-ipafont-gothic \
+        fonts-wqy-zenhei \
+        fonts-thai-tlwg \
+        fonts-kacst \
+        fonts-freefont-ttf && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -185,7 +185,7 @@ RUN apt-get update && \
 #
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      socat && \
+        socat && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -199,7 +199,7 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 #
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      xvfb && \
+        xvfb && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -217,7 +217,7 @@ RUN /usr/src/features/src/desktop-lite/install.sh
 ##############################
 
 RUN usermod -aG audio ${user_name} && \
-  usermod -aG video ${user_name}
+    usermod -aG video ${user_name}
 
 USER ${user_name}
 
@@ -292,7 +292,7 @@ COPY --chmod=755 start-supervised.sh /usr/local/bin/start-supervised.sh
 
 # Health check for CDP availability
 HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
-  CMD curl -sf http://localhost:9222/json/version || exit 1
+    CMD curl -sf http://localhost:9222/json/version || exit 1
 
 ENTRYPOINT ["/usr/local/share/desktop-init.sh"]
 CMD ["/usr/local/bin/start-supervised.sh"]

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -72,9 +72,15 @@ FROM debian:bookworm-20260316
 ARG user_name=developer
 ARG user_id
 ARG group_id
-ARG features_repository="https://github.com/uraitakahito/features.git"
+# https://github.com/uraitakahito/dotfiles/releases/tag/1.1.0
 ARG dotfiles_repository="https://github.com/uraitakahito/dotfiles.git"
+ARG dotfiles_commit="0484e07cffd330d86e1f914c33a008ba2d9cba37"
+# https://github.com/uraitakahito/features/releases/tag/1.0.0
+ARG features_repository="https://github.com/uraitakahito/features.git"
+ARG features_commit="e8d887d2e17e79f5289b0e8a087dd0730dcad24e"
+# https://github.com/uraitakahito/extra-utils/releases/tag/1.0.0
 ARG extra_utils_repository="https://github.com/uraitakahito/extra-utils.git"
+ARG extra_utils_commit="3fb9cf4625cdd57270adc48ddf1b230cf151fdf0"
 
 # Avoid warnings by switching to noninteractive for the build process
 ENV DEBIAN_FRONTEND=noninteractive
@@ -98,7 +104,9 @@ RUN apt-get update -qq && \
 # clone features
 #
 RUN cd /usr/src && \
-  git clone --depth 1 ${features_repository}
+    git clone ${features_repository} && \
+    cd features && \
+    git checkout ${features_commit}
 
 #
 # Add user and install common utils.
@@ -121,12 +129,19 @@ RUN USERNAME=${user_name} \
 # Install extra utils.
 #
 RUN cd /usr/src && \
-  git clone --depth 1 ${extra_utils_repository} && \
-  ADDEZA=true \
-  ADDCLAUDECODE=true \
-  # Claude Code is installed under $HOME, so the username must be specified.
-  USERNAME=${user_name} \
-    /usr/src/extra-utils/utils/install.sh
+    git clone ${extra_utils_repository} && \
+    cd extra-utils && \
+    git checkout ${extra_utils_commit} && \
+    ADDEZA=true \
+    ADDGRPCURL=true \
+    ADDHADOLINT=true \
+    \
+    ADDCLAUDECODE=true \
+    # Claude Code is installed under $HOME, so the username must be specified.
+    USERNAME=${user_name} \
+    \
+    UPGRADEPACKAGES=false \
+        /usr/src/extra-utils/utils/install.sh
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
@@ -210,8 +225,10 @@ USER ${user_name}
 # dotfiles
 #
 RUN cd /home/${user_name} && \
-  git clone --depth 1 ${dotfiles_repository} && \
-  dotfiles/install.sh
+    git clone ${dotfiles_repository} && \
+    cd dotfiles && \
+    git checkout ${dotfiles_commit} && \
+    ./install.sh
 
 ####################################
 #  Puppeteer support starts here   #

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -53,11 +53,11 @@ ENV TZ="$TZ"
 # Git
 #
 RUN apt-get update -qq && \
-  apt-get install -y -qq --no-install-recommends \
-    ca-certificates \
-    git && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/*
+    apt-get install -y -qq --no-install-recommends \
+        ca-certificates \
+        git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 #
 # clone features
@@ -78,7 +78,7 @@ RUN USERNAME=${user_name} \
     USERGID=${group_id} \
     CONFIGUREZSHASDEFAULTSHELL=true \
     UPGRADEPACKAGES=false \
-      /usr/src/features/src/common-utils/install.sh
+        /usr/src/features/src/common-utils/install.sh
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
@@ -86,13 +86,13 @@ RUN USERNAME=${user_name} \
 # https://zenn.dev/tom1111/articles/0dc7cde5c8e9bf
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      chromium \
-      chromium-sandbox \
-      fonts-ipafont-gothic \
-      fonts-wqy-zenhei \
-      fonts-thai-tlwg \
-      fonts-kacst \
-      fonts-freefont-ttf && \
+        chromium \
+        chromium-sandbox \
+        fonts-ipafont-gothic \
+        fonts-wqy-zenhei \
+        fonts-thai-tlwg \
+        fonts-kacst \
+        fonts-freefont-ttf && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -122,7 +122,7 @@ RUN apt-get update && \
 #
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      socat && \
+        socat && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -155,7 +155,7 @@ COPY --chmod=644 chromium-headless.conf /app/chromium-headless.conf
 
 # Health check for CDP availability
 HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
-  CMD curl -sf http://localhost:9222/json/version || exit 1
+    CMD curl -sf http://localhost:9222/json/version || exit 1
 
 # Headless mode execution (Xvfb not required)
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/app.conf"]

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -29,13 +29,17 @@
 #
 
 # Debian 12.13 slim variant
-FROM debian:bookworm-20260202-slim
+FROM debian:bookworm-20260316-slim
 
 ARG user_name=developer
 ARG user_id
 ARG group_id
-ARG dotfiles_repository="https://github.com/uraitakahito/dotfiles-production.git"
+# https://github.com/uraitakahito/dotfiles/releases/tag/1.1.0
+ARG dotfiles_repository="https://github.com/uraitakahito/dotfiles.git"
+ARG dotfiles_commit="0484e07cffd330d86e1f914c33a008ba2d9cba37"
+# https://github.com/uraitakahito/features/releases/tag/1.0.0
 ARG features_repository="https://github.com/uraitakahito/features.git"
+ARG features_commit="e8d887d2e17e79f5289b0e8a087dd0730dcad24e"
 
 # Avoid warnings by switching to noninteractive for the build process
 ENV DEBIAN_FRONTEND=noninteractive
@@ -59,7 +63,9 @@ RUN apt-get update -qq && \
 # clone features
 #
 RUN cd /usr/src && \
-  git clone --depth 1 ${features_repository}
+    git clone ${features_repository} && \
+    cd features && \
+    git checkout ${features_commit}
 
 #
 # Add user and install common utils.
@@ -126,9 +132,11 @@ USER ${user_name}
 # dotfiles (minimal configuration for production)
 #
 RUN cd /home/${user_name} && \
-  git clone --depth 1 ${dotfiles_repository} dotfiles && \
-  ln -sf ~/dotfiles/.vimrc ~/.vimrc && \
-  ln -sf ~/dotfiles/.tmux.conf ~/.tmux.conf
+    git clone ${dotfiles_repository} && \
+    cd dotfiles && \
+    git checkout ${dotfiles_commit} && \
+    ln -sf ~/dotfiles/.vimrc ~/.vimrc && \
+    ln -sf ~/dotfiles/.tmux.conf ~/.tmux.conf
 
 WORKDIR /app
 


### PR DESCRIPTION
- **Fix: Correct chromium config file path in development Dockerfile**
  The COPY destination path was /app/chromium.conf but supervisord-headful.conf
  expects /app/chromium-headful.conf. This mismatch caused start-chromium.sh
  to fail when CHROMIUM_CONFIG pointed to a non-existent file.
  
  🤖 Generated with [Claude Code](https://claude.com/claude-code)
  
  Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
  

- **Refactor: Remove SSH agent preparation instructions from Dockerfile**
  

- **Fix: Add GH_TOKEN environment variable to Docker run instructions**
  

- **Refactor: Remove unnecessary login instructions from Dockerfile**
  

- **Refactor: Clarify comment regarding ownership change for command history folder**
  

- **Refactor: Remove launch instructions for Claude from Dockerfile**
  

- **Update base image to Debian 12.13 in Dockerfile**
  

- **Refactor: Update verification instructions for Chromium operations in Dockerfile**
  

- **Fix: Add rpcinterface section to supervisord configs for supervisorctl support**
  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
  

- **Refactor: Use official install script for Claude Code instead of nvm/npm**
  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
  

- **Refactor: Add option to add user to root group for ssh-agent access in install script**
  

- **Refactor: Add option to install Claude Code with specified username in Dockerfile**
  

- **Refactor: Update comments in Dockerfile for clarity on build and volume creation steps**
  

- **Refactor: Remove Node.js installation from Dockerfile and update container run commands**
  

- **Refactor: Add locale support for Unicode characters in Dockerfile**
  

- **Refactor: Set default timezone to UTC in Dockerfile**
  

- **Refactor: Remove unnecessary comments related to locale and timezone in Dockerfile**
  

- **Refactor: Remove duplicate installation of extra utils in Dockerfile**
  

- **Refactor: Update Debian slim variant to 12.13 in Dockerfile**
  

- **Refactor: Set default language environment variable in Dockerfile**
  

- **Refactor: Add timezone argument to Dockerfile**
  

- **Refactor: Update Debian base image to 12.13 in Dockerfile**
  

- **Refactor: Pin specific commits for features, dotfiles, and extra utils in Dockerfile**
  

- **Refactor: Update Debian slim variant and enhance git clone commands in Dockerfile**
  

- **Refactor: Format Dockerfile for improved readability and consistency**
  