### PR TITLE
Bump base images, drop dead Xvfb install, fix disk-cache overflow

### DIFF
--- a/chromium-headful.conf
+++ b/chromium-headful.conf
@@ -19,5 +19,6 @@
 --password-store=basic
 --start-maximized
 --disable-blink-features=AutomationControlled
---disk-cache-size=2147483648
+# 1 GiB. Must stay under int32 max (2147483647); Chromium silently rejects larger values.
+--disk-cache-size=1073741824
 --user-data-dir=/tmp/chrome-profile

--- a/chromium-headless.conf
+++ b/chromium-headless.conf
@@ -18,5 +18,6 @@
 --no-sandbox
 --disable-setuid-sandbox
 --disable-blink-features=AutomationControlled
---disk-cache-size=2147483648
+# 1 GiB. Must stay under int32 max (2147483647); Chromium silently rejects larger values.
+--disk-cache-size=1073741824
 --user-data-dir=/tmp/chrome-profile

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -67,7 +67,7 @@
 #
 
 # Debian 12.13
-FROM debian:bookworm-20260316
+FROM debian:bookworm-20260421
 
 ARG user_name=developer
 ARG user_id

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -193,16 +193,6 @@ RUN apt-get update && \
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
-#
-# Xvfb (X Virtual Framebuffer)
-# Provides a virtual display for VNC-based visual debugging
-#
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        xvfb && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 ##############################
 #  VNC support starts here   #
 ##############################

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -72,15 +72,15 @@ FROM debian:bookworm-20260421
 ARG user_name=developer
 ARG user_id
 ARG group_id
-# https://github.com/uraitakahito/dotfiles/releases/tag/1.1.0
+# https://github.com/uraitakahito/dotfiles/releases/tag/1.1.4
 ARG dotfiles_repository="https://github.com/uraitakahito/dotfiles.git"
-ARG dotfiles_commit="0484e07cffd330d86e1f914c33a008ba2d9cba37"
+ARG dotfiles_commit="622bb525a8a46275871bfdc7cf2826c1c489021a"
 # https://github.com/uraitakahito/features/releases/tag/1.0.0
 ARG features_repository="https://github.com/uraitakahito/features.git"
 ARG features_commit="e8d887d2e17e79f5289b0e8a087dd0730dcad24e"
-# https://github.com/uraitakahito/extra-utils/releases/tag/1.0.0
+# https://github.com/uraitakahito/extra-utils/releases/tag/1.1.0
 ARG extra_utils_repository="https://github.com/uraitakahito/extra-utils.git"
-ARG extra_utils_commit="3fb9cf4625cdd57270adc48ddf1b230cf151fdf0"
+ARG extra_utils_commit="2c5b1ab72c7b98b2a9c42c084aa6b67cdaa36625"
 
 # Avoid warnings by switching to noninteractive for the build process
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -29,7 +29,7 @@
 #
 
 # Debian 12.13 slim variant
-FROM debian:bookworm-20260316-slim
+FROM debian:bookworm-20260421-slim
 
 ARG user_name=developer
 ARG user_id

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -34,9 +34,9 @@ FROM debian:bookworm-20260421-slim
 ARG user_name=developer
 ARG user_id
 ARG group_id
-# https://github.com/uraitakahito/dotfiles/releases/tag/1.1.0
+# https://github.com/uraitakahito/dotfiles/releases/tag/1.1.4
 ARG dotfiles_repository="https://github.com/uraitakahito/dotfiles.git"
-ARG dotfiles_commit="0484e07cffd330d86e1f914c33a008ba2d9cba37"
+ARG dotfiles_commit="622bb525a8a46275871bfdc7cf2826c1c489021a"
 # https://github.com/uraitakahito/features/releases/tag/1.0.0
 ARG features_repository="https://github.com/uraitakahito/features.git"
 ARG features_commit="e8d887d2e17e79f5289b0e8a087dd0730dcad24e"


### PR DESCRIPTION
## Summary

Four changes accumulated on `develop` since the last `main` sync:

- **Bump Debian base image** to `bookworm-20260421` / `bookworm-20260421-slim` in both Dockerfiles.
- **Bump pinned upstreams**: `dotfiles` → `622bb52` (1.1.4) and `extra-utils` → `2c5b1ab` (1.1.0). `features` is unchanged.
- **Remove unused Xvfb install** from the development image. The X server has always been `Xtigervnc` (from desktop-lite); Xvfb was installed but never started. Verified before removal that nothing in `desktop-init.sh`, `features/desktop-lite/install.sh`, or the apt reverse-deps referenced `xvfb`. Saves ~9 MB.
- **Fix `--disk-cache-size` int32 overflow** in both `chromium-headless.conf` and `chromium-headful.conf`. The old value `2147483648` (2³¹) overflowed signed int32, so Chromium silently rejected it on every startup (`ERROR: ... The value 2147483648 of disk-cache-size can not be converted to integer, ignoring!`) and fell back to the default ~80 MB cache. New value is `1073741824` (1 GiB) with an inline comment about the int32 limit.

Open Dependabot PRs for the same Debian base bump (`debian-bookworm-20260421` / `-slim`) will be superseded by this PR and auto-close on merge.

## Test plan

- [x] `hadolint --config .hadolint.yaml` clean on both Dockerfiles
- [x] Production image builds locally; CDP returns `webSocketDebuggerUrl` at `/json/version` (smoke equivalent)
- [x] Development image builds locally; CDP returns headful `Chrome/...` User-Agent; noVNC HTTP 200; supervisord shows `chromium`+`socat` running
- [x] After fix, `chromium-stderr.log` contains zero `can not be converted to integer` errors in both variants; `ps` shows `--disk-cache-size=1073741824`
- [x] After Xvfb removal, `dpkg -l xvfb` reports no package and `/usr/bin/Xvfb` is absent in the development image
- [ ] CI: `docker-build` matrix + smoke job pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)