### PR TITLE
Switch production dotfiles to dedicated dotfiles-production repo

### DIFF
--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -34,9 +34,9 @@ FROM debian:bookworm-20260421-slim
 ARG user_name=developer
 ARG user_id
 ARG group_id
-# https://github.com/uraitakahito/dotfiles/releases/tag/1.1.4
-ARG dotfiles_repository="https://github.com/uraitakahito/dotfiles.git"
-ARG dotfiles_commit="622bb525a8a46275871bfdc7cf2826c1c489021a"
+# https://github.com/uraitakahito/dotfiles-production/releases/tag/1.0.0
+ARG dotfiles_repository="https://github.com/uraitakahito/dotfiles-production.git"
+ARG dotfiles_commit="ed6bb006bb418acb57e127bcc7d1033f40a63432"
 # https://github.com/uraitakahito/features/releases/tag/1.0.0
 ARG features_repository="https://github.com/uraitakahito/features.git"
 ARG features_commit="e8d887d2e17e79f5289b0e8a087dd0730dcad24e"
@@ -129,14 +129,13 @@ RUN apt-get update && \
 USER ${user_name}
 
 #
-# dotfiles (minimal configuration for production)
+# dotfiles
 #
 RUN cd /home/${user_name} && \
     git clone ${dotfiles_repository} && \
-    cd dotfiles && \
+    cd dotfiles-production && \
     git checkout ${dotfiles_commit} && \
-    ln -sf ~/dotfiles/.vimrc ~/.vimrc && \
-    ln -sf ~/dotfiles/.tmux.conf ~/.tmux.conf
+    ./install.sh
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Replace `uraitakahito/dotfiles` (full env) with `uraitakahito/dotfiles-production` (slim repo: `.vimrc` + `.tmux.conf` + `install.sh`) for the production image.
- Drop the hand-written `ln -sf ~/dotfiles/.vimrc ...` lines and call `./install.sh` instead, matching the development Dockerfile pattern.
- Pin to release `1.0.0` (SHA `ed6bb006bb418acb57e127bcc7d1033f40a63432`).

## Why
- Production needs only `.vimrc` / `.tmux.conf`. Cloning the full dotfiles repo just to symlink two files wastes layer space.
- Centralizing the symlink logic in the dotfiles-production `install.sh` avoids touching this Dockerfile every time the dotfiles file list changes.
- Both Dockerfiles now share one install pattern (clone → checkout pinned SHA → `./install.sh`).

## Test plan
- [x] Local build of production image succeeds
- [x] Container starts and `/json/version` returns `webSocketDebuggerUrl` within 30s
- [x] `~/.vimrc` and `~/.tmux.conf` are symlinks pointing into `~/dotfiles-production/`
- [ ] CI `docker-build` matrix (production) green
- [ ] CI `docker-build` smoke job green
- [ ] CI `hadolint` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)