### PR TITLE
Reduce Chromium startup noise via flag policy + dbus session

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ desktop environment so OS-integration probes (keychain,
 gnome-keyring, etc.) must be suppressed. See the inline comments in
 `chromium-{headless,headful}.conf` for the per-flag rationale.
 
+The image installs the `dbus` package and wraps Chromium in
+`dbus-run-session` (see `start-chromium.sh`) so a fresh per-process
+session bus is spawned for every Chromium launch. This suppresses
+the session-bus probes Chromium emits at startup. The system bus is
+intentionally left unreachable (no `dbus-daemon --system`); the
+residual stderr noise from UPower / NetworkManager probes is treated
+as known noise and filtered at the log-aggregation layer if needed.
+`dbus-x11` and `DBUS_SESSION_BUS_ADDRESS=autolaunch:` are deliberately
+NOT used — autolaunch requires `$DISPLAY` and is therefore unusable
+in a fully-headless container.
+
 **Two separate Dockerfiles are available:**
 - **Production** : Headless Chromium with minimal footprint
 - **Development** : Full-featured environment with VNC, Node.js, and development tools

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ A Docker environment for running Chromium with Chrome DevTools Protocol (CDP) su
 
 This project provides Docker environments for running Chromium with Chrome DevTools Protocol (CDP) support.
 
+The image is intended to be driven externally over CDP (e.g. by
+[BrowserHive](https://github.com/uraitakahito/browserhive)). Chromium
+is launched with a small, opinionated set of flags chosen to make
+this driving model predictable: each worker is expected to reuse one
+tab for its lifetime, navigations to `about:blank` are expected to
+fully tear down the previous document, and the container has no
+desktop environment so OS-integration probes (keychain,
+gnome-keyring, etc.) must be suppressed. See the inline comments in
+`chromium-{headless,headful}.conf` for the per-flag rationale.
+
 **Two separate Dockerfiles are available:**
 - **Production** : Headless Chromium with minimal footprint
 - **Development** : Full-featured environment with VNC, Node.js, and development tools

--- a/chromium-headful.conf
+++ b/chromium-headful.conf
@@ -16,9 +16,48 @@
 --disable-gpu
 --no-sandbox
 --disable-setuid-sandbox
+# Pin the credential store to `basic` to suppress keychain auto-detection.
+#
+# On Linux, Chromium probes available credential backends at startup in
+# the order:
+#   1) GNOME Keyring (libsecret)
+#   2) KWallet (over D-Bus)
+#   3) basic (encrypted file under the user data dir)
+# This image (Debian slim, no desktop environment) has neither (1) nor
+# (2), so the probes always fail and emit noise to stderr on every
+# launch. Forcing `basic` skips the probe path entirely.
+#
+# Why `basic` is safe here: this image is driven over CDP for
+# automated capture and never asks the user to save passwords, so the
+# weaker on-disk encryption that `basic` uses is moot. The headless
+# variant (chromium-headless.conf) carries this flag for the same reason.
 --password-store=basic
 --start-maximized
 --disable-blink-features=AutomationControlled
+# Disable Chromium's Back-Forward Cache (bfcache).
+#
+# bfcache keeps the previous document's DOM, JS execution context,
+# timers, and event listeners alive in memory so a user pressing
+# "back" / "forward" sees an instant restore. Enabled by default in
+# Chromium 86+.
+#
+# Why we turn it off:
+# This image is intended to be driven over CDP by an external worker
+# (e.g. BrowserHive) that owns one persistent tab for its entire
+# lifetime and resets state between tasks by navigating to
+# `about:blank` plus clearing cookies via CDP. With bfcache on, that
+# `about:blank` navigation does not actually destroy the previous
+# document — the previous tab is suspended into the cache instead,
+# leaving DOM, timers, and listeners alive across the task boundary.
+# That defeats the inter-task isolation the driver is trying to
+# achieve and lets state, fingerprint surfaces, and resource usage
+# bleed between captures.
+#
+# bfcache's upside (instant back / forward) does not apply to a
+# CDP-driven, no-human-interaction capture pipeline. Playwright,
+# Puppeteer, and browsertrix-crawler all disable bfcache by default
+# for the same reason.
+--disable-back-forward-cache
 # 1 GiB. Must stay under int32 max (2147483647); Chromium silently rejects larger values.
 --disk-cache-size=1073741824
 --user-data-dir=/tmp/chrome-profile

--- a/chromium-headless.conf
+++ b/chromium-headless.conf
@@ -17,7 +17,47 @@
 --disable-gpu
 --no-sandbox
 --disable-setuid-sandbox
+# Pin the credential store to `basic` to suppress keychain auto-detection.
+#
+# On Linux, Chromium probes available credential backends at startup in
+# the order:
+#   1) GNOME Keyring (libsecret)
+#   2) KWallet (over D-Bus)
+#   3) basic (encrypted file under the user data dir)
+# This image (Debian slim, no desktop environment) has neither (1) nor
+# (2), so the probes always fail and emit noise to stderr on every
+# launch. Forcing `basic` skips the probe path entirely.
+#
+# Why `basic` is safe here: this image is driven over CDP for
+# automated capture and never asks the user to save passwords, so the
+# weaker on-disk encryption that `basic` uses is moot. The headful
+# variant (chromium-headful.conf) carries this flag for the same reason.
+--password-store=basic
 --disable-blink-features=AutomationControlled
+# Disable Chromium's Back-Forward Cache (bfcache).
+#
+# bfcache keeps the previous document's DOM, JS execution context,
+# timers, and event listeners alive in memory so a user pressing
+# "back" / "forward" sees an instant restore. Enabled by default in
+# Chromium 86+.
+#
+# Why we turn it off:
+# This image is intended to be driven over CDP by an external worker
+# (e.g. BrowserHive) that owns one persistent tab for its entire
+# lifetime and resets state between tasks by navigating to
+# `about:blank` plus clearing cookies via CDP. With bfcache on, that
+# `about:blank` navigation does not actually destroy the previous
+# document — the previous tab is suspended into the cache instead,
+# leaving DOM, timers, and listeners alive across the task boundary.
+# That defeats the inter-task isolation the driver is trying to
+# achieve and lets state, fingerprint surfaces, and resource usage
+# bleed between captures.
+#
+# bfcache's upside (instant back / forward) does not apply to a
+# CDP-driven, no-human-interaction capture pipeline. Playwright,
+# Puppeteer, and browsertrix-crawler all disable bfcache by default
+# for the same reason.
+--disable-back-forward-cache
 # 1 GiB. Must stay under int32 max (2147483647); Chromium silently rejects larger values.
 --disk-cache-size=1073741824
 --user-data-dir=/tmp/chrome-profile

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -160,6 +160,42 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 #
+# dbus daemon for session-bus wrapping
+#
+# Chromium probes the dbus session bus at startup for several
+# subsystems (Notifications, ScreenSaver, AT-SPI). Without any
+# session bus reachable, each probe emits a "Failed to connect to
+# the bus" line to stderr on every container launch.
+#
+# We install the `dbus` package because `start-chromium.sh` invokes
+# `dbus-run-session chromium ...`. That helper, shipped in `dbus`,
+# spawns a fresh per-process session bus, exports
+# DBUS_SESSION_BUS_ADDRESS for the wrapped command, forwards
+# SIGHUP/SIGTERM/SIGINT to the child, and tears the daemon down
+# when chromium exits. No long-lived dbus daemon is needed in
+# supervisord.
+#
+# Why NOT `dbus-x11` + DBUS_SESSION_BUS_ADDRESS=autolaunch:
+# `dbus-launch --autolaunch` (from `dbus-x11`) requires $DISPLAY
+# — it uses an X11 atom to coordinate daemons — and refuses to
+# spawn without it. Empirically broken in fully-headless containers
+# like this one, so `dbus-x11` is deliberately NOT installed.
+#
+# Scope: this silences SESSION-bus errors only. SYSTEM-bus probes
+# (UPower, NetworkManager, BlueZ) still fail because
+# `dbus-daemon --system` is intentionally not running — running it
+# would require a long-lived root daemon and contradict this image's
+# "thin CDP container" stance. Remaining system-bus stderr
+# noise is acknowledged and left for log-aggregation-layer
+# filtering.
+#
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        dbus && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+#
 # supervisor for process management
 #
 RUN apt-get update && \

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -97,6 +97,42 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 #
+# dbus daemon for session-bus wrapping
+#
+# Chromium probes the dbus session bus at startup for several
+# subsystems (Notifications, ScreenSaver, AT-SPI). Without any
+# session bus reachable, each probe emits a "Failed to connect to
+# the bus" line to stderr on every container launch.
+#
+# We install the `dbus` package because `start-chromium.sh` invokes
+# `dbus-run-session chromium ...`. That helper, shipped in `dbus`,
+# spawns a fresh per-process session bus, exports
+# DBUS_SESSION_BUS_ADDRESS for the wrapped command, forwards
+# SIGHUP/SIGTERM/SIGINT to the child, and tears the daemon down
+# when chromium exits. No long-lived dbus daemon is needed in
+# supervisord.
+#
+# Why NOT `dbus-x11` + DBUS_SESSION_BUS_ADDRESS=autolaunch:
+# `dbus-launch --autolaunch` (from `dbus-x11`) requires $DISPLAY
+# — it uses an X11 atom to coordinate daemons — and refuses to
+# spawn without it. Empirically broken in fully-headless containers
+# like this one, so `dbus-x11` is deliberately NOT installed.
+#
+# Scope: this silences SESSION-bus errors only. SYSTEM-bus probes
+# (UPower, NetworkManager, BlueZ) still fail because
+# `dbus-daemon --system` is intentionally not running — running it
+# would require a long-lived root daemon and contradict this image's
+# "thin CDP container" stance. Remaining system-bus stderr
+# noise is acknowledged and left for log-aggregation-layer
+# filtering.
+#
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        dbus && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+#
 # supervisor for process management
 #
 RUN apt-get update && \

--- a/start-chromium.sh
+++ b/start-chromium.sh
@@ -44,7 +44,27 @@ CHROMIUM_ARGS=$(grep -v '^[[:space:]]*#' "${CONFIG_FILE}" | grep -v '^[[:space:]
 echo "Starting Chromium with config: ${CONFIG_FILE}"
 echo "Arguments: ${CHROMIUM_ARGS}"
 
+# Wrap Chromium in `dbus-run-session` so a fresh per-process session
+# dbus-daemon is spawned and DBUS_SESSION_BUS_ADDRESS is exported
+# before chromium starts. This silences the session-bus probes
+# Chromium emits at startup (Notifications, ScreenSaver, AT-SPI)
+# without needing a long-lived dbus daemon in supervisord.
+#
+# Why dbus-run-session and not `dbus-launch --autolaunch`:
+# autolaunch (from `dbus-x11`) refuses to spawn a daemon when
+# $DISPLAY is not set — it uses an X11 atom to coordinate. Unusable
+# in a fully-headless container. dbus-run-session (in the `dbus`
+# package) has no such X11 dependency, forwards SIGHUP/SIGTERM/
+# SIGINT to its child (so supervisord's graceful shutdown still
+# reaches Chromium correctly), and tears the daemon down
+# automatically when chromium exits.
+#
+# Scope: SESSION bus only. SYSTEM-bus probes (UPower,
+# NetworkManager, BlueZ) remain unsuppressed by design — running
+# `dbus-daemon --system` would require a long-lived root daemon
+# and contradict this image's "thin CDP container" stance.
+#
 # Word splitting is intentional: each whitespace-separated token must become
 # its own argv entry so chromium parses one flag per element.
 # shellcheck disable=SC2086
-exec chromium ${CHROMIUM_ARGS}
+exec dbus-run-session chromium ${CHROMIUM_ARGS}


### PR DESCRIPTION
## Summary
- Add `--password-store=basic` (parity with headful) and `--disable-back-forward-cache` (both variants) so Chromium stops probing nonexistent keychain backends and stops keeping suspended documents alive across the `about:blank` resets that BrowserHive uses for inter-task isolation. Inline comments in `chromium-{headless,headful}.conf` document the rationale per flag.
- Wrap Chromium in `dbus-run-session` (`start-chromium.sh`) and install the `dbus` package so a fresh per-process session bus is spawned for every launch, silencing the session-bus probe failures Chromium emits at startup. `dbus-x11`/`DBUS_SESSION_BUS_ADDRESS=autolaunch:` deliberately not used — autolaunch requires `$DISPLAY` and is unusable in a fully-headless container. `dbus-run-session` forwards SIGHUP/SIGTERM/SIGINT to the child, so supervisord's graceful shutdown still reaches Chromium correctly.
- README updated with both the opinionated-flag policy and the dbus posture, so future contributors can read the rationale upfront. System-bus probes (UPower, NetworkManager) are intentionally not addressed — running `dbus-daemon --system` would require a long-lived root daemon and contradict this image's "thin CDP container" stance.

## Test plan
- [ ] Build the production image: `docker image build -f docker/production/Dockerfile -t chromium-server-docker:test . --build-arg user_id=$(id -u) --build-arg group_id=$(id -g)`
- [ ] Start the container: `docker container run -d --rm --init -p 9222:9222 --name t chromium-server-docker:test && sleep 6`
- [ ] CDP reachable: `curl -s http://localhost:9222/json/version` returns the Chrome version JSON
- [ ] Keychain noise gone: `docker exec t sh -c 'cat /tmp/chromium-stderr.log' | grep -iE 'keyring|kwallet|libsecret'` is empty
- [ ] Session-bus errors gone: `docker exec t sh -c 'cat /tmp/chromium-stderr.log' | grep -cE 'session_bus_socket|autolaunch'` prints `0`
- [ ] `dbus-daemon` is actually running: `docker exec t pidof dbus-daemon` prints a PID; `docker exec t sh -c 'ps -eo pid,user,cmd | grep "[d]bus-daemon"'` shows `dbus-daemon --nofork --print-address 4 --session` under the `developer` user
- [ ] System-bus errors persist as expected: `docker exec t sh -c 'cat /tmp/chromium-stderr.log' | grep -c system_bus_socket` is non-zero (design choice; ~5 lines)
- [ ] Graceful shutdown is fast: `time docker stop t` completes in well under 10s (in local testing it returned in 0.39s — SIGTERM forwarded correctly by dbus-run-session)
- [ ] (Optional) Build the development image and repeat the checks: `docker image build -f docker/development/Dockerfile -t chromium-server-docker:dev-test . --build-arg user_id=$(id -u) --build-arg group_id=$(id -g) --build-arg TZ=Asia/Tokyo`
- [ ] (Optional) End-to-end smoke against the consumer (e.g. BrowserHive's `compose.dev.yaml`): rebuild from a clean state, run a capture via `POST /v1/captures`, confirm the artifact lands in SeaweedFS

🤖 Generated with [Claude Code](https://claude.com/claude-code)