### PR TITLE
Bump Debian base and remove dotfiles from production image

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -67,7 +67,7 @@
 #
 
 # Debian 12.13
-FROM debian:bookworm-20260421
+FROM debian:bookworm-20260505
 
 ARG user_name=developer
 ARG user_id

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -29,7 +29,7 @@
 #
 
 # Debian 12.13 slim variant
-FROM debian:bookworm-20260421-slim
+FROM debian:bookworm-20260505-slim
 
 ARG user_name=developer
 ARG user_id

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -8,7 +8,6 @@
 # - Minimal footprint without Node.js or development tools
 # - Chrome DevTools Protocol access on port 9222 via socat
 # - Use with external CDP client connecting remotely
-# - Minimal dotfiles (vim, tmux) from dotfiles-production repository
 # - Based on Debian slim variant for reduced image size
 #
 # ## From Docker build to login
@@ -34,9 +33,6 @@ FROM debian:bookworm-20260505-slim
 ARG user_name=developer
 ARG user_id
 ARG group_id
-# https://github.com/uraitakahito/dotfiles-production/releases/tag/1.0.0
-ARG dotfiles_repository="https://github.com/uraitakahito/dotfiles-production.git"
-ARG dotfiles_commit="ed6bb006bb418acb57e127bcc7d1033f40a63432"
 # https://github.com/uraitakahito/features/releases/tag/1.0.0
 ARG features_repository="https://github.com/uraitakahito/features.git"
 ARG features_commit="e8d887d2e17e79f5289b0e8a087dd0730dcad24e"
@@ -163,15 +159,6 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 USER ${user_name}
-
-#
-# dotfiles
-#
-RUN cd /home/${user_name} && \
-    git clone ${dotfiles_repository} && \
-    cd dotfiles-production && \
-    git checkout ${dotfiles_commit} && \
-    ./install.sh
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Bump the Debian base image from `bookworm-20260421` to `bookworm-20260505` (slim variant for production, regular for development).
- Remove the dotfiles install from `docker/production/Dockerfile`. The production image is run only as a non-interactive CDP backend under supervisord — no human shell uses vim/tmux there, and the install was the only reason the image carried an extra `git clone` after the `USER` switch. Mirrors `browserhive/Dockerfile.prod`. The development variant retains dotfiles since it is intended for interactive work (noVNC, VS Code attach).

## Test plan
- [ ] Build the production image: `docker image build -f docker/production/Dockerfile -t chromium-server-docker:test . --build-arg user_id=$(id -u) --build-arg group_id=$(id -g)`
- [ ] Container becomes healthy: `docker container run -d --rm --init -p 9222:9222 --name t chromium-server-docker:test && sleep 6 && docker container ps --filter name=t --format '{{.Status}}'` shows `Up ... (healthy)`
- [ ] CDP reachable: `curl -s http://localhost:9222/json/version` returns the Chrome 147 JSON
- [ ] Process tree as expected: `docker exec t sh -c 'ps -eo pid,ppid,user,cmd --forest'` shows `supervisord → dbus-run-session → {dbus-daemon, chromium}`, all running under the `developer` user
- [ ] No regression in earlier improvements:
  - Session-bus / autolaunch errors zero: `docker exec t sh -c 'cat /tmp/chromium-stderr.log' | grep -cE 'session_bus_socket|autolaunch'` prints `0`
  - Keychain noise zero: `docker exec t sh -c 'cat /tmp/chromium-stderr.log' | grep -ciE 'keyring|kwallet|libsecret'` prints `0`
- [ ] Graceful shutdown: `time docker stop t` completes well under 10s
- [ ] No `dotfiles` layer in image history: `docker image history chromium-server-docker:test --no-trunc | grep -i dotfiles` is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)