### PR TITLE
Refactor: Update Debian base image to version 20260518 in Dockerfiles

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -67,7 +67,7 @@
 #
 
 # Debian 12.13
-FROM debian:bookworm-20260505
+FROM debian:bookworm-20260518
 
 ARG user_name=developer
 ARG user_id

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -28,7 +28,7 @@
 #
 
 # Debian 12.13 slim variant
-FROM debian:bookworm-20260505-slim
+FROM debian:bookworm-20260518-slim
 
 ARG user_name=developer
 ARG user_id


### PR DESCRIPTION
## Summary
- Bump `debian:bookworm-20260505` → `debian:bookworm-20260518` in both production (slim) and development Dockerfiles
- 13-day snapshot bump, no functional changes expected

## Test plan
- [x] Local build: `docker image build -f docker/production/Dockerfile ...` succeeds
- [x] Local CDP smoke: container starts, `curl http://localhost:9222/json/version` returns `webSocketDebuggerUrl` (responded in 1s, Chrome 148)
- [ ] CI `docker-build` job (both variants) passes
- [ ] CI `smoke` job (production CDP) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)