### PR TITLE
Refactor: Update dotfiles to 1.1.9 in development Dockerfile

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -72,9 +72,9 @@ FROM debian:bookworm-20260518
 ARG user_name=developer
 ARG user_id
 ARG group_id
-# https://github.com/uraitakahito/dotfiles/releases/tag/1.1.4
+# https://github.com/uraitakahito/dotfiles/releases/tag/1.1.9
 ARG dotfiles_repository="https://github.com/uraitakahito/dotfiles.git"
-ARG dotfiles_commit="622bb525a8a46275871bfdc7cf2826c1c489021a"
+ARG dotfiles_commit="89501545e6d91811f549d031f65244cd7e0df87a"
 # https://github.com/uraitakahito/features/releases/tag/2.0.1
 ARG features_repository="https://github.com/uraitakahito/features.git"
 ARG features_commit="9f7e672e27207f374d56e5da7f862b0b5b110b3f"


### PR DESCRIPTION
## Summary
- Bump `dotfiles` 1.1.4 → 1.1.9 (commit `622bb525` → `89501545`)
- 43 commits, all configuration/policy additions:
  - Claude Code `settings.json` allowlist expansions (git, docker, docker-compose, aws read-only subcommands)
  - pnpm v11 config migration (`pnpmfile.js` → `config.yaml`)
  - New `statusline.sh` for 5h/7d rate-limit usage display
  - Centralize `.claude/*` ignore rules under `config/git/ignore`
- No structural change to `install.sh`

## Test plan
- [x] Local dev build succeeds
- [x] `~/dotfiles` at exact 1.1.9 commit (`89501545`)
- [x] zsh remains default shell for `developer`
- [x] `~/.claude/CLAUDE.md`, `settings.json`, `statusline.sh` symlinks installed
- [x] supervisord chromium + socat running, CDP up in ~1s
- [ ] CI `docker-build` (development variant) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)