### PR TITLE
Refactor: Update features to 2.0.1 in Dockerfiles

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -75,9 +75,9 @@ ARG group_id
 # https://github.com/uraitakahito/dotfiles/releases/tag/1.1.4
 ARG dotfiles_repository="https://github.com/uraitakahito/dotfiles.git"
 ARG dotfiles_commit="622bb525a8a46275871bfdc7cf2826c1c489021a"
-# https://github.com/uraitakahito/features/releases/tag/1.0.0
+# https://github.com/uraitakahito/features/releases/tag/2.0.1
 ARG features_repository="https://github.com/uraitakahito/features.git"
-ARG features_commit="e8d887d2e17e79f5289b0e8a087dd0730dcad24e"
+ARG features_commit="9f7e672e27207f374d56e5da7f862b0b5b110b3f"
 # https://github.com/uraitakahito/extra-utils/releases/tag/1.1.0
 ARG extra_utils_repository="https://github.com/uraitakahito/extra-utils.git"
 ARG extra_utils_commit="2c5b1ab72c7b98b2a9c42c084aa6b67cdaa36625"
@@ -112,7 +112,7 @@ RUN cd /usr/src && \
 # Add user and install common utils.
 #
 # For the list of installed packages, see:
-#   https://github.com/uraitakahito/features/blob/deb6cf416fda206b99c7b771e9caa12e6952f9c7/src/common-utils/main.sh#L35-L78
+#   https://github.com/uraitakahito/features/blob/9f7e672e27207f374d56e5da7f862b0b5b110b3f/src/common-utils/main.sh#L35-L79
 #
 RUN USERNAME=${user_name} \
     USERUID=${user_id} \
@@ -121,7 +121,7 @@ RUN USERNAME=${user_name} \
     UPGRADEPACKAGES=false \
     # When using ssh-agent inside Docker, add the user to the root group
     # to ensure permission to access the mounted socket.
-    #   https://github.com/uraitakahito/features/blob/59e8acea74ff0accd5c2c6f98ede1191a9e3b2aa/src/common-utils/main.sh#L467-L471
+    #   https://github.com/uraitakahito/features/blob/9f7e672e27207f374d56e5da7f862b0b5b110b3f/src/common-utils/main.sh#L490-L495
     ADDUSERTOROOTGROUP=true \
         /usr/src/features/src/common-utils/install.sh
 

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -33,9 +33,9 @@ FROM debian:bookworm-20260505-slim
 ARG user_name=developer
 ARG user_id
 ARG group_id
-# https://github.com/uraitakahito/features/releases/tag/1.0.0
+# https://github.com/uraitakahito/features/releases/tag/2.0.1
 ARG features_repository="https://github.com/uraitakahito/features.git"
-ARG features_commit="e8d887d2e17e79f5289b0e8a087dd0730dcad24e"
+ARG features_commit="9f7e672e27207f374d56e5da7f862b0b5b110b3f"
 
 # Avoid warnings by switching to noninteractive for the build process
 ENV DEBIAN_FRONTEND=noninteractive
@@ -67,7 +67,7 @@ RUN cd /usr/src && \
 # Add user and install common utils.
 #
 # For the list of installed packages, see:
-#   https://github.com/uraitakahito/features/blob/deb6cf416fda206b99c7b771e9caa12e6952f9c7/src/common-utils/main.sh#L35-L78
+#   https://github.com/uraitakahito/features/blob/9f7e672e27207f374d56e5da7f862b0b5b110b3f/src/common-utils/main.sh#L35-L79
 #
 RUN USERNAME=${user_name} \
     USERUID=${user_id} \


### PR DESCRIPTION
## Summary
- Bump `features` 1.0.0 → 2.0.1 (commit `e8d887d2` → `9f7e672e`), affecting both production and development Dockerfiles
- Major-version bump bringing in upstream `devcontainers/features` sync through May 2026 release cohort, fork's `common-utils` 2.6.1
- Doc-URL realignment: comment links now track the pinned commit instead of two unrelated stale SHAs (`deb6cf41` and `59e8acea`)

## What changes upstream
- `common-utils` ➜ 2.6.1: bubblewrap conditional install for RHEL (no impact, image is Debian); per-package idempotency; AWS-CLI ZSH completion via site-functions
- `desktop-lite` ➜ 1.2.9: heredoc entrypoint args fix; log-message formatting
- `docker-in-docker`: containerd 2.3.x erofs snapshotter fix, **Alpine support dropped** (no impact, this image doesn't use docker-in-docker)
- Bumps across `node`, `aws-cli`, `dotnet`, `conda`, `terraform`, etc.

## Compatibility verified
- `ADDUSERTOROOTGROUP`, `CONFIGUREZSHASDEFAULTSHELL`, `UPGRADEPACKAGES` env-var contracts still honored (`src/common-utils/main.sh:13,16,22`)
- `curl` still pulled in transitively by `common-utils` package list (`main.sh:46`) — HEALTHCHECK preserved

## Test plan
- [x] Local **production** build succeeds
- [x] Production: `/usr/bin/curl` present; CDP up in 1s; chromium + socat both `RUNNING` under supervisord; stderr noise level matches known floor
- [x] Local **development** build succeeds
- [x] Development: `developer` in root group (ADDUSERTOROOTGROUP); zsh default shell; Xtigervnc + fluxbox + noVNC 1.6.0 launched by desktop-lite entrypoint; CDP up in 1s
- [ ] CI `docker-build` (both variants) passes
- [ ] CI `smoke` job (production CDP) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)