### PR TITLE
Bump Debian base and external feature/dotfiles/extra-utils pins

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -78,9 +78,9 @@ ARG dotfiles_commit="622bb525a8a46275871bfdc7cf2826c1c489021a"
 # https://github.com/uraitakahito/features/releases/tag/2.0.1
 ARG features_repository="https://github.com/uraitakahito/features.git"
 ARG features_commit="9f7e672e27207f374d56e5da7f862b0b5b110b3f"
-# https://github.com/uraitakahito/extra-utils/releases/tag/1.1.0
+# https://github.com/uraitakahito/extra-utils/releases/tag/1.3.0
 ARG extra_utils_repository="https://github.com/uraitakahito/extra-utils.git"
-ARG extra_utils_commit="2c5b1ab72c7b98b2a9c42c084aa6b67cdaa36625"
+ARG extra_utils_commit="f975dbcb18f44b518cc181cedad57fd790d9894a"
 
 # Avoid warnings by switching to noninteractive for the build process
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -72,9 +72,9 @@ FROM debian:bookworm-20260518
 ARG user_name=developer
 ARG user_id
 ARG group_id
-# https://github.com/uraitakahito/dotfiles/releases/tag/1.1.4
+# https://github.com/uraitakahito/dotfiles/releases/tag/1.1.9
 ARG dotfiles_repository="https://github.com/uraitakahito/dotfiles.git"
-ARG dotfiles_commit="622bb525a8a46275871bfdc7cf2826c1c489021a"
+ARG dotfiles_commit="89501545e6d91811f549d031f65244cd7e0df87a"
 # https://github.com/uraitakahito/features/releases/tag/2.0.1
 ARG features_repository="https://github.com/uraitakahito/features.git"
 ARG features_commit="9f7e672e27207f374d56e5da7f862b0b5b110b3f"

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -75,9 +75,9 @@ ARG group_id
 # https://github.com/uraitakahito/dotfiles/releases/tag/1.1.4
 ARG dotfiles_repository="https://github.com/uraitakahito/dotfiles.git"
 ARG dotfiles_commit="622bb525a8a46275871bfdc7cf2826c1c489021a"
-# https://github.com/uraitakahito/features/releases/tag/1.0.0
+# https://github.com/uraitakahito/features/releases/tag/2.0.1
 ARG features_repository="https://github.com/uraitakahito/features.git"
-ARG features_commit="e8d887d2e17e79f5289b0e8a087dd0730dcad24e"
+ARG features_commit="9f7e672e27207f374d56e5da7f862b0b5b110b3f"
 # https://github.com/uraitakahito/extra-utils/releases/tag/1.1.0
 ARG extra_utils_repository="https://github.com/uraitakahito/extra-utils.git"
 ARG extra_utils_commit="2c5b1ab72c7b98b2a9c42c084aa6b67cdaa36625"
@@ -112,7 +112,7 @@ RUN cd /usr/src && \
 # Add user and install common utils.
 #
 # For the list of installed packages, see:
-#   https://github.com/uraitakahito/features/blob/deb6cf416fda206b99c7b771e9caa12e6952f9c7/src/common-utils/main.sh#L35-L78
+#   https://github.com/uraitakahito/features/blob/9f7e672e27207f374d56e5da7f862b0b5b110b3f/src/common-utils/main.sh#L35-L79
 #
 RUN USERNAME=${user_name} \
     USERUID=${user_id} \
@@ -121,7 +121,7 @@ RUN USERNAME=${user_name} \
     UPGRADEPACKAGES=false \
     # When using ssh-agent inside Docker, add the user to the root group
     # to ensure permission to access the mounted socket.
-    #   https://github.com/uraitakahito/features/blob/59e8acea74ff0accd5c2c6f98ede1191a9e3b2aa/src/common-utils/main.sh#L467-L471
+    #   https://github.com/uraitakahito/features/blob/9f7e672e27207f374d56e5da7f862b0b5b110b3f/src/common-utils/main.sh#L490-L495
     ADDUSERTOROOTGROUP=true \
         /usr/src/features/src/common-utils/install.sh
 

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -67,7 +67,7 @@
 #
 
 # Debian 12.13
-FROM debian:bookworm-20260505
+FROM debian:bookworm-20260518
 
 ARG user_name=developer
 ARG user_id

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -28,7 +28,7 @@
 #
 
 # Debian 12.13 slim variant
-FROM debian:bookworm-20260505-slim
+FROM debian:bookworm-20260518-slim
 
 ARG user_name=developer
 ARG user_id

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -33,9 +33,9 @@ FROM debian:bookworm-20260505-slim
 ARG user_name=developer
 ARG user_id
 ARG group_id
-# https://github.com/uraitakahito/features/releases/tag/1.0.0
+# https://github.com/uraitakahito/features/releases/tag/2.0.1
 ARG features_repository="https://github.com/uraitakahito/features.git"
-ARG features_commit="e8d887d2e17e79f5289b0e8a087dd0730dcad24e"
+ARG features_commit="9f7e672e27207f374d56e5da7f862b0b5b110b3f"
 
 # Avoid warnings by switching to noninteractive for the build process
 ENV DEBIAN_FRONTEND=noninteractive
@@ -67,7 +67,7 @@ RUN cd /usr/src && \
 # Add user and install common utils.
 #
 # For the list of installed packages, see:
-#   https://github.com/uraitakahito/features/blob/deb6cf416fda206b99c7b771e9caa12e6952f9c7/src/common-utils/main.sh#L35-L78
+#   https://github.com/uraitakahito/features/blob/9f7e672e27207f374d56e5da7f862b0b5b110b3f/src/common-utils/main.sh#L35-L79
 #
 RUN USERNAME=${user_name} \
     USERUID=${user_id} \


### PR DESCRIPTION
## Summary

Routine sync of base image + external repository pins. Four bumps landed on `develop` via separate PRs (#35, #36, #37, #38), now flowing to `main`.

| Component | Before | After | Notes |
|---|---|---|---|
| Debian base (both Dockerfiles) | `bookworm-20260505` | `bookworm-20260518` | Snapshot bump |
| `features` (both Dockerfiles) | `1.0.0` (`e8d887d2`) | `2.0.1` (`9f7e672e`) | **Major** — upstream sync (May 2026 cohort) + common-utils 2.6.1. Alpine drop is in docker-in-docker only (unused here). Env-var contracts (ADDUSERTOROOTGROUP, CONFIGUREZSHASDEFAULTSHELL, UPGRADEPACKAGES) preserved; `curl` still transitively installed (HEALTHCHECK safe). Doc-URL comments realigned to the new pin. |
| `extra-utils` (dev) | `1.1.0` (`2c5b1ab7`) | `1.3.0` (`f975dbcb`) | New `ADDXXD`/`ADDGITLEAKS` opt-ins; used flags (`ADDEZA`, `ADDGRPCURL`, `ADDHADOLINT`, `ADDCLAUDECODE`) unchanged. |
| `dotfiles` (dev) | `1.1.4` (`622bb525`) | `1.1.9` (`89501545`) | Claude Code `settings.json` allowlist expansions, pnpm v11 config migration, statusline script. |

## Verification (already done on individual PRs)
- Production build + CDP `/json/version` smoke (1s, Chrome 148)
- Development build + supervisord chromium/socat RUNNING + desktop-lite Xtigervnc + fluxbox + noVNC 1.6.0 launched
- All CI checks green on #35, #36, #37, #38 prior to merge

## Test plan
- [ ] Watch CI runs on this PR (docker-build matrix + CDP smoke + hadolint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)