### PR TITLE
Refactor: Pin Debian base by digest in production Dockerfile

### DIFF
--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -27,8 +27,9 @@
 #   curl http://localhost:9222/json/version
 #
 
-# Debian 12.13 slim variant
-FROM debian:bookworm-20260518-slim
+# Debian 12.13 slim variant. Tag retained for human-readable provenance;
+# multi-arch manifest list digest pins the actual bits we resolve to.
+FROM debian:bookworm-20260518-slim@sha256:0104b334637a5f19aa9c983a91b54c89887c0984081f2068983107a6f6c21eeb
 
 ARG user_name=developer
 ARG user_id


### PR DESCRIPTION
## Summary
- Move production's base from a bare snapshot tag (`debian:bookworm-20260518-slim`) to a tag-plus-digest reference (`debian:bookworm-20260518-slim@sha256:0104b334...`)
- Multi-arch manifest list digest, so a future cross-arch build resolves to the same logical "bookworm-20260518-slim" set
- Human-readable tag is retained in the source so reviewers and Dependabot still see "20260518"

## Why
Snapshot tags on Docker Hub are not contractually immutable. Pinning by digest is the only way to guarantee bit-for-bit reproducibility on the production image. development is intentionally left on the bare tag for now (more churn there, and dev image is not load-bearing).

## Stage in the broader plan
This is **Stage 1** of the production Dockerfile structural plan (see `private-note/production-dockerfile-evolution-plan.html`). Stage 2 (drop `features` fork dependency from production) follows in a separate PR.

## Test plan
- [x] Local build succeeds against the digest
- [x] Production container starts; CDP responds at `/json/version` in ~1s (Chrome 148)
- [x] Docker HEALTHCHECK transitions `starting` → `healthy` within 4s (start_period 15s)
- [ ] CI `docker-build` (matrix prod/dev) passes
- [ ] CI `smoke` (production CDP) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)