### PR TITLE
Refactor: Drop features fork dependency from production Dockerfile

### DIFF
--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -33,9 +33,6 @@ FROM debian:bookworm-20260518-slim
 ARG user_name=developer
 ARG user_id
 ARG group_id
-# https://github.com/uraitakahito/features/releases/tag/2.0.1
-ARG features_repository="https://github.com/uraitakahito/features.git"
-ARG features_commit="9f7e672e27207f374d56e5da7f862b0b5b110b3f"
 
 # Avoid warnings by switching to noninteractive for the build process
 ENV DEBIAN_FRONTEND=noninteractive
@@ -46,35 +43,26 @@ ARG TZ=UTC
 ENV TZ="$TZ"
 
 #
-# Git
+# Create unprivileged user + install runtime essentials.
 #
-RUN apt-get update -qq && \
-    apt-get install -y -qq --no-install-recommends \
+# HEALTHCHECK depends on `curl`; keep it explicit here so future
+# refactors of this Dockerfile cannot silently drop it. `ca-certificates`
+# is needed for any TLS the container might do (CDP itself is plain HTTP
+# locally, but downstream code paths may reach TLS endpoints).
+#
+# We intentionally do NOT pull in a wider utility set (jq, htop, sudo,
+# manpages, etc.). This image is driven externally over CDP and is not
+# meant to be `docker exec`-ed into for ad-hoc operations.
+#
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
         ca-certificates \
-        git && \
+        curl && \
+    groupadd --gid ${group_id} ${user_name} && \
+    useradd --uid ${user_id} --gid ${group_id} \
+            --create-home --shell /bin/bash ${user_name} && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-#
-# clone features
-#
-RUN cd /usr/src && \
-    git clone ${features_repository} && \
-    cd features && \
-    git checkout ${features_commit}
-
-#
-# Add user and install common utils.
-#
-# For the list of installed packages, see:
-#   https://github.com/uraitakahito/features/blob/9f7e672e27207f374d56e5da7f862b0b5b110b3f/src/common-utils/main.sh#L35-L79
-#
-RUN USERNAME=${user_name} \
-    USERUID=${user_id} \
-    USERGID=${group_id} \
-    CONFIGUREZSHASDEFAULTSHELL=true \
-    UPGRADEPACKAGES=false \
-        /usr/src/features/src/common-utils/install.sh
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer


### PR DESCRIPTION
## Summary

**Stage 2** of the production Dockerfile structural plan (see `private-note/production-dockerfile-evolution-plan.html`). Removes the `uraitakahito/features` fork dependency from production. development is intentionally untouched (it still needs features for `desktop-lite`).

## What changes

- Drop `ARG features_repository` and `ARG features_commit`
- Drop the `git clone uraitakahito/features` layer
- Drop the `common-utils/install.sh` invocation (the full ~40-package install)
- Replace with one explicit RUN: `apt-get install ca-certificates curl`, then `groupadd`+`useradd` for the unprivileged user
- Remove `git` from the production runtime (it was only present to clone the features repo)

## Why

| Concern | Resolution |
|---|---|
| Features fork value to production | `ADDUSERTOROOTGROUP` was always dev-only; production never set it. The fork's value was not flowing to production. |
| HEALTHCHECK fragility | `curl` was reaching production *transitively* via the features common-utils package list (memory's noted footgun). Now installed explicitly. |
| Image bloat | ~40 utilities (jq, htop, sudo, manpages, locales, libkrb5, libicu, ncdu, …) that a CDP-driven server never uses. |
| Layer count | 3 separate RUNs (Git / clone / install.sh) collapsed into 1 RUN. |

## Measured impact

| Metric | Before | After | Delta |
|---|---|---|---|
| Image size | 1000.3 MB | 816.6 MB | **-183.7 MB (-18.4%)** |
| RootFS layers | 12 | 10 | -2 |
| Pinned external repos | 1 (features) | 0 | -1 to maintain |

## Test plan

- [x] Local build succeeds without features clone
- [x] `/usr/bin/curl` present (HEALTHCHECK guaranteed)
- [x] `/usr/src/features` absent — confirms fork is fully gone from production
- [x] `git` not installed in production runtime (was only for cloning features)
- [x] `developer` user: `uid=1001 gid=1001(developer)` — clean own-group (no incidental dialout/audio/video membership from common-utils)
- [x] CDP up in 1s (Chrome 148)
- [x] HEALTHCHECK `starting` → `healthy` in 2s (start_period 15s)
- [x] supervisord shows chromium + socat RUNNING
- [x] stderr noise floor unchanged (5 "Failed to connect" lines — known dbus system-bus residual)
- [ ] CI `docker-build` (production variant) passes
- [ ] CI `smoke` (production CDP) passes
- [ ] CI `docker-build` (development variant) unchanged — still uses features

🤖 Generated with [Claude Code](https://claude.com/claude-code)