### PR TITLE
Slim down production Dockerfile: Debian digest pin + drop features fork

### DIFF
--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -34,9 +34,6 @@ FROM debian:bookworm-20260518-slim@sha256:0104b334637a5f19aa9c983a91b54c89887c09
 ARG user_name=developer
 ARG user_id
 ARG group_id
-# https://github.com/uraitakahito/features/releases/tag/2.0.1
-ARG features_repository="https://github.com/uraitakahito/features.git"
-ARG features_commit="9f7e672e27207f374d56e5da7f862b0b5b110b3f"
 
 # Avoid warnings by switching to noninteractive for the build process
 ENV DEBIAN_FRONTEND=noninteractive
@@ -47,35 +44,26 @@ ARG TZ=UTC
 ENV TZ="$TZ"
 
 #
-# Git
+# Create unprivileged user + install runtime essentials.
 #
-RUN apt-get update -qq && \
-    apt-get install -y -qq --no-install-recommends \
+# HEALTHCHECK depends on `curl`; keep it explicit here so future
+# refactors of this Dockerfile cannot silently drop it. `ca-certificates`
+# is needed for any TLS the container might do (CDP itself is plain HTTP
+# locally, but downstream code paths may reach TLS endpoints).
+#
+# We intentionally do NOT pull in a wider utility set (jq, htop, sudo,
+# manpages, etc.). This image is driven externally over CDP and is not
+# meant to be `docker exec`-ed into for ad-hoc operations.
+#
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
         ca-certificates \
-        git && \
+        curl && \
+    groupadd --gid ${group_id} ${user_name} && \
+    useradd --uid ${user_id} --gid ${group_id} \
+            --create-home --shell /bin/bash ${user_name} && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-#
-# clone features
-#
-RUN cd /usr/src && \
-    git clone ${features_repository} && \
-    cd features && \
-    git checkout ${features_commit}
-
-#
-# Add user and install common utils.
-#
-# For the list of installed packages, see:
-#   https://github.com/uraitakahito/features/blob/9f7e672e27207f374d56e5da7f862b0b5b110b3f/src/common-utils/main.sh#L35-L79
-#
-RUN USERNAME=${user_name} \
-    USERUID=${user_id} \
-    USERGID=${group_id} \
-    CONFIGUREZSHASDEFAULTSHELL=true \
-    UPGRADEPACKAGES=false \
-        /usr/src/features/src/common-utils/install.sh
 
 # Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
 # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -27,8 +27,9 @@
 #   curl http://localhost:9222/json/version
 #
 
-# Debian 12.13 slim variant
-FROM debian:bookworm-20260518-slim
+# Debian 12.13 slim variant. Tag retained for human-readable provenance;
+# multi-arch manifest list digest pins the actual bits we resolve to.
+FROM debian:bookworm-20260518-slim@sha256:0104b334637a5f19aa9c983a91b54c89887c0984081f2068983107a6f6c21eeb
 
 ARG user_name=developer
 ARG user_id


### PR DESCRIPTION
## Summary

Two structural changes landed on develop via PRs #40 and #41. Both are production-only — the development Dockerfile is untouched on this PR. See `private-note/production-dockerfile-evolution-plan.html` (local) for the multi-stage rationale.

### Stage 1 — Debian base pinned by digest (#40)
- `FROM debian:bookworm-20260518-slim` → `FROM debian:bookworm-20260518-slim@sha256:0104b334...` (multi-arch manifest list digest)
- Human-readable tag retained for provenance; the digest guarantees bit-for-bit reproducibility

### Stage 2 — Drop the `uraitakahito/features` fork dependency from production (#41)
- Remove `features_repository` / `features_commit` ARGs
- Remove the `git clone` layer and the `common-utils/install.sh` invocation (~40-package install: `jq`, `htop`, `sudo`, `manpages`, `locales`, `libkrb5`, etc.)
- Replace with one explicit RUN that installs `ca-certificates` + `curl` and creates the unprivileged user via `groupadd`/`useradd`
- `git` is also dropped from production (it was only there to clone the features repo)

### Measured impact (Stage 2)

| Metric | Before | After | Delta |
|---|---|---|---|
| Image size | 1000.3 MB | 816.6 MB | **-183.7 MB (-18.4%)** |
| RootFS layers | 12 | 10 | -2 |
| External repos pinned (production) | 1 | 0 | -1 to maintain |

### Why this is safe
- `ADDUSERTOROOTGROUP` was always dev-only — production never set it, so dropping the fork has no behavioral change there
- `curl` was reaching production *transitively* through the features package list (a known footgun documented in memory) — now installed explicitly, so HEALTHCHECK can no longer break implicitly
- Development Dockerfile still uses features (it needs `desktop-lite`); the dev image build matrix in CI is unchanged

### End-to-end verification (local, combined Stage 1+2 image)
- `Browser.getVersion` over WS: Chrome 148, V8 14.8 — `HeadlessChrome` in UA confirms `--headless` applied
- `Page.navigate` (data: URL) + `loadEventFired`: 38 ms
- `Runtime.evaluate`: DOM accessible, JS executed, `navigator.webdriver=false` (confirms `--disable-blink-features=AutomationControlled` applied)
- `Page.captureScreenshot`: 166 KB PNG, 780×440, 100 ms
- `Target.getTargets`: only 1 page (no residual)
- HEALTHCHECK: `starting` → `healthy` in 2s (start_period 15s)

### Test plan
- [x] Local build (production) succeeds against the combined diff
- [x] Local CDP smoke (`/json/version`) responds in 1s
- [x] Local end-to-end CDP drive (navigate + screenshot + JS eval) succeeds
- [x] HEALTHCHECK transitions to healthy
- [x] `/usr/src/features` and `git` are absent from the production image
- [x] CI green on both #40 and #41 (docker-build matrix + production CDP smoke + hadolint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)