### PR TITLE
Refactor: Drop user_id/group_id ARGs from production Dockerfile

### DIFF
--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -14,7 +14,7 @@
 #
 # ### Build the Docker image
 #
-#   PROJECT=$(basename `pwd`) && docker image build -f docker/production/Dockerfile -t $PROJECT-image:production . --build-arg user_id=`id -u` --build-arg group_id=`id -g`
+#   PROJECT=$(basename `pwd`) && docker image build -f docker/production/Dockerfile -t $PROJECT-image:production .
 #
 # ### Run the container
 #
@@ -31,9 +31,18 @@
 # multi-arch manifest list digest pins the actual bits we resolve to.
 FROM debian:bookworm-20260518-slim@sha256:0104b334637a5f19aa9c983a91b54c89887c0984081f2068983107a6f6c21eeb
 
-ARG user_name=developer
-ARG user_id
-ARG group_id
+# Production image runs Chromium as an unprivileged system user. The
+# user / group are created with --system so their UID / GID land in
+# the Debian system range (100-999), avoiding collisions with arbitrary
+# host UID / GID values that build-time ARGs would have to pass
+# through. (macOS hosts default to GID 20 for the `staff` group, which
+# collides with Debian's `dialout` group at the same GID; an explicit
+# `groupadd --gid 20` fails on those hosts with no useful diagnostic.)
+#
+# Bind mounts are intentionally NOT used on production chromium-server
+# containers, so matching host file ownership is not a requirement
+# here. The development image keeps the ARG-based user creation
+# because dev *does* bind-mount source code under /app.
 
 # Avoid warnings by switching to noninteractive for the build process
 ENV DEBIAN_FRONTEND=noninteractive
@@ -59,9 +68,9 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl && \
-    groupadd --gid ${group_id} ${user_name} && \
-    useradd --uid ${user_id} --gid ${group_id} \
-            --create-home --shell /bin/bash ${user_name} && \
+    groupadd --system chromium && \
+    useradd --system --gid chromium \
+            --create-home --shell /bin/bash chromium && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -147,13 +156,13 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-USER ${user_name}
+USER chromium
 
 WORKDIR /app
 
 # Copy supervisor configuration and startup script
 # Note: --chmod=644 is required because:
-#   - The container runs as 'developer' user (non-root)
+#   - The container runs as 'chromium' user (non-root)
 #   - Without explicit chmod, COPY preserves the source file's permissions
 #   - If the source file has 600 permissions, supervisord cannot read it
 #


### PR DESCRIPTION
## Summary

Drops `user_id` / `group_id` (and the no-longer-needed `user_name`) build args from the **production** Dockerfile and switches user creation to `groupadd --system` / `useradd --system`, picking the UID/GID from Debian's system range (100-999). The development Dockerfile is unchanged.

## Why

Production chromium-server containers hold no bind mounts (verified against the downstream `browserhive/compose.prod.yaml`: no `volumes:` field on any `chromium-server-*` service). The build-arg interface that lets callers pass host UID/GID was a hold-over from the development image and serves no functional purpose here.

Concretely, on macOS hosts where the default `staff` group is GID 20, the current `0.4.0` production build fails:

```
groupadd: GID '20' already exists
```

The Debian base reserves GID 20 for `dialout`. `0.3.0` hid this via the features fork's `common-utils/install.sh` (which mutated existing groups instead of calling bare `groupadd`); after the features fork was dropped in #41, the raw `groupadd --gid ${group_id}` exposed the host-GID dependency.

## What changes

| Item | Before | After |
|---|---|---|
| `ARG user_name=developer` | declared | removed |
| `ARG user_id` | declared, required | removed |
| `ARG group_id` | declared, required | removed |
| user creation | `groupadd --gid ${group_id} ${user_name}` + `useradd --uid ${user_id} --gid ${group_id} ...` | `groupadd --system chromium` + `useradd --system --gid chromium ...` |
| `USER ${user_name}` | literal var | `USER chromium` |
| build-command example | `--build-arg user_id=\`id -u\` --build-arg group_id=\`id -g\`` | no args |
| `--chmod=644` comment | "runs as 'developer' user" | "runs as 'chromium' user" |

## Backward compatibility

Existing callers that pass `--build-arg user_id=501 --build-arg group_id=20` continue to work — Docker emits a "warning" for undeclared args but does **not** fail the build. So this is non-breaking at the CLI surface.

The development Dockerfile is intentionally **untouched**: it bind-mounts host source under `/app` and the features fork it still uses handles GID collisions internally.

## Test plan

Tested locally on macOS (Darwin arm64, GID 20 = staff):

- [x] `docker image build -f docker/production/Dockerfile .` (no args) → succeeds, image 856 MB
- [x] `docker image build --build-arg user_id=501 --build-arg group_id=20 ...` → succeeds with one "undefined build arg" warning, same image SHA
- [x] `docker run --rm <image> id chromium` → `uid=999(chromium) gid=999(chromium) groups=999(chromium)`
- [x] `docker run -d -p 19222:9222 <image>` + `curl http://localhost:19222/json/version` → returns Chrome 148.0.7778.178
- [x] `docker logs` shows supervisord successfully spawning chromium and socat as the `chromium` user
- [ ] Linux x86_64 (requires reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)