### PR TITLE
ci(docs-site): deploy Pages from main instead of develop

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -2,12 +2,12 @@ name: docs-site
 
 # Build the Astro + Starlight docs site in docs-site/ and publish it to GitHub Pages.
 #   - pull_request: build only (a read-only check; never deploys).
-#   - push to develop / manual dispatch: build + deploy to Pages.
+#   - push to main / manual dispatch: build + deploy to Pages.
 # Enable once under Settings -> Pages -> Source: "GitHub Actions".
 
 on:
   push:
-    branches: [develop]
+    branches: [main]
     paths:
       - 'docs-site/**'
       - '.github/workflows/docs-site.yml'
@@ -48,7 +48,7 @@ jobs:
 
   deploy:
     name: Deploy to GitHub Pages
-    # PRs run the build check only; publishing happens on develop / manual dispatch.
+    # PRs run the build check only; publishing happens on main / manual dispatch.
     if: ${{ github.event_name != 'pull_request' }}
     needs: build
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ docs site:
 - **日本語** — <https://uraitakahito.github.io/chromium-server-docker/ja/>
 
 The site is built from [`docs-site/`](docs-site/) (Astro + Starlight) and
-published to GitHub Pages on every push to `develop`.
+published to GitHub Pages on every push to `main`.
 
 To edit or preview the docs locally:
 


### PR DESCRIPTION
## Why

The first Pages deploy failed: the `github-pages` environment only permits deployments from the default branch (`main`), but the workflow deployed from `develop`, so the deploy job was rejected by the environment protection rule.

## Change

- Deploy trigger `push: [develop]` → `push: [main]`. The release merge into `main` now publishes the docs; `develop` pushes no longer run a deploy that is doomed to fail.
- PR build-check (`pull_request`) and `workflow_dispatch` behavior unchanged.

## Effect

Merging this PR pushes `main`, which triggers `docs-site.yml` on `main` (an allowed branch) → build + deploy → publishes to <https://uraitakahito.github.io/chromium-server-docker/>.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
