### PR TITLE
fix(docs): lowercase the derived image name in build commands

### DIFF
--- a/docs-site/src/content/docs/getting-started/development.md
+++ b/docs-site/src/content/docs/getting-started/development.md
@@ -20,8 +20,8 @@ These commands assume a macOS host (they mount the host SSH-agent socket at
 ## Build the image
 
 ```sh
-PROJECT=$(basename `pwd`)
-docker image build -f docker/development/Dockerfile -t $PROJECT-image:development . \
+PROJECT=$(basename "$PWD" | tr '[:upper:]' '[:lower:]')
+docker image build -f docker/development/Dockerfile -t "$PROJECT-image:development" . \
   --build-arg user_id=`id -u` \
   --build-arg group_id=`id -g` \
   --build-arg TZ=Asia/Tokyo

--- a/docs-site/src/content/docs/getting-started/production.md
+++ b/docs-site/src/content/docs/getting-started/production.md
@@ -15,8 +15,8 @@ from the directory name so the image tag matches the project.
 ## Build the image
 
 ```sh
-PROJECT=$(basename `pwd`)
-docker image build -f docker/production/Dockerfile -t $PROJECT-image:production .
+PROJECT=$(basename "$PWD" | tr '[:upper:]' '[:lower:]')
+docker image build -f docker/production/Dockerfile -t "$PROJECT-image:production" .
 ```
 
 ## Create the network (first time only)

--- a/docs-site/src/content/docs/ja/getting-started/development.md
+++ b/docs-site/src/content/docs/ja/getting-started/development.md
@@ -19,8 +19,8 @@ Development イメージは、Chromium を開発・観察するためのフル�
 ## イメージを build する
 
 ```sh
-PROJECT=$(basename `pwd`)
-docker image build -f docker/development/Dockerfile -t $PROJECT-image:development . \
+PROJECT=$(basename "$PWD" | tr '[:upper:]' '[:lower:]')
+docker image build -f docker/development/Dockerfile -t "$PROJECT-image:development" . \
   --build-arg user_id=`id -u` \
   --build-arg group_id=`id -g` \
   --build-arg TZ=Asia/Tokyo

--- a/docs-site/src/content/docs/ja/getting-started/production.md
+++ b/docs-site/src/content/docs/ja/getting-started/production.md
@@ -14,8 +14,8 @@ Production イメージは **ヘッドレス** Chromium を最小構成（Node.j
 ## イメージを build する
 
 ```sh
-PROJECT=$(basename `pwd`)
-docker image build -f docker/production/Dockerfile -t $PROJECT-image:production .
+PROJECT=$(basename "$PWD" | tr '[:upper:]' '[:lower:]')
+docker image build -f docker/production/Dockerfile -t "$PROJECT-image:production" .
 ```
 
 ## network を作成する（初回のみ）


### PR DESCRIPTION
## Why

`PROJECT=$(basename "$PWD")` in the documented build commands inherits the checkout folder name verbatim. If that directory has uppercase letters (e.g. cloned as `Chromium-Server-Docker`), `docker build -t "$PROJECT-image:..."` fails with `repository name must be lowercase` before the build even starts — Docker repository names must be lowercase.

## Fix

Pipe the derived name through `tr '[:upper:]' '[:lower:]'` and quote the tag, in `getting-started/production` and `getting-started/development` (en + ja):

```sh
PROJECT=$(basename "$PWD" | tr '[:upper:]' '[:lower:]')
docker image build ... -t "$PROJECT-image:production" .
```

## Verification

- Simulated a `Foo-BAR-Baz` directory → the fixed snippet yields the valid tag `foo-bar-baz-image:production` and `docker build` succeeds (the uppercase form errors with "repository name must be lowercase").
- `astro build` still passes (14 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
