### PR TITLE
feat: add bin/cdp.sh and consolidate verification into one docs page

### DIFF
--- a/bin/cdp.sh
+++ b/bin/cdp.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+#
+# cdp.sh — zero-dependency CDP helper for quick verification.
+#
+# Talks to a chromium-server worker over the Chrome DevTools Protocol using
+# nothing but Node's built-in fetch/WebSocket (Node 22+). No npm install,
+# no throwaway scripts.
+#
+#   ./bin/cdp.sh smoke [url]     # version + open a page + print its title
+#   ./bin/cdp.sh goto <url>      # navigate and wait for the load event
+#   ./bin/cdp.sh title           # print document.title
+#   ./bin/cdp.sh eval <expr>     # evaluate a JS expression, print the result
+#   ./bin/cdp.sh shot <file.png> # save a screenshot of the page
+#   ./bin/cdp.sh targets         # list open tabs (url + title)
+#
+# Worker selection: $CDP_TARGET (worker name), else the first of
+# chromium-debug, chromium-1, chromium-*. Exits non-zero on any failure,
+# so it can back automated smoke checks as-is.
+#
+set -euo pipefail
+CMD="${1:-help}"; shift || true
+
+# --- resolve worker name: CDP_TARGET -> chromium-debug -> chromium-1 -> chromium-* ---
+NAME="${CDP_TARGET:-}"
+if [ -z "$NAME" ]; then
+    NAME=$(container ls --format json | python3 -c '
+import json, sys
+ids = [c.get("configuration", {}).get("id", "") for c in json.load(sys.stdin)]
+for cand in ("chromium-debug", "chromium-1"):
+    if cand in ids:
+        print(cand)
+        break
+else:
+    workers = [i for i in ids if i.startswith("chromium-")]
+    print(workers[0] if workers else "")')
+fi
+if [ -z "$NAME" ]; then
+    echo "error: no chromium-* worker running (start one: ./bin/dev.sh or ./bin/prod.sh)" >&2
+    exit 1
+fi
+
+# --- resolve worker IP ---
+if ! IP=$(container inspect "$NAME" 2>/dev/null | python3 -c 'import json, sys
+d = json.load(sys.stdin); d = d[0] if isinstance(d, list) else d
+print(d["status"]["networks"][0]["ipv4Address"].split("/")[0])' 2>/dev/null) || [ -z "$IP" ]; then
+    echo "error: worker \"${NAME}\" not found or not running (check: container ls)" >&2
+    exit 1
+fi
+
+# --- CDP proper: Node built-in fetch + WebSocket (zero dependencies) ---
+# The embedded JS must not contain single quotes (it is single-quoted here).
+# shellcheck disable=SC2016  # ${...} below are JS template literals, not shell
+NAME="$NAME" exec node --input-type=module -e '
+const [ip, cmd, ...args] = process.argv.slice(1);
+const base = `http://${ip}:9222`;
+const j = async (p, o) => (await fetch(base + p, o)).json();
+
+const usage = "usage: cdp.sh smoke [url] | goto URL | title | eval EXPR | shot FILE.png | targets";
+if (cmd === "help" || cmd === "--help" || cmd === "-h") { console.log(usage); process.exit(0); }
+
+try {
+  if (cmd === "targets") {           // HTTP only, no WebSocket needed
+    for (const t of await j("/json/list"))
+      if (t.type === "page") console.log(`${t.url}\t${t.title}`);
+    process.exit(0);
+  }
+
+  // Ensure a page target exists: reuse the first open tab, create one only if
+  // none exists. (PUT /json/new ignores its url= parameter on current
+  // Chromium — measured — but plain tab creation still works.)
+  const page = (await j("/json/list")).find(t => t.type === "page")
+            ?? await j("/json/new", { method: "PUT" });
+
+  const ws = new WebSocket(page.webSocketDebuggerUrl);
+  await new Promise((ok, ng) => {
+    ws.onopen = ok;
+    ws.onerror = () => ng(new Error(`cannot connect to ${page.webSocketDebuggerUrl}`));
+  });
+  // Watchdog: a wedged connection must not hang the CLI forever. unref-ed so
+  // it never delays a normal exit.
+  setTimeout(() => { console.error("error: CDP call timed out"); process.exit(1); }, 30000).unref();
+
+  let seq = 0;
+  const pending = new Map(), waiters = new Map();
+  ws.onmessage = (e) => {
+    const m = JSON.parse(e.data);
+    if (m.id && pending.has(m.id)) { pending.get(m.id)(m.result); pending.delete(m.id); }
+    if (m.method && waiters.has(m.method)) { waiters.get(m.method)(); waiters.delete(m.method); }
+  };
+  const call = (method, params = {}) =>
+    new Promise(ok => { pending.set(++seq, ok); ws.send(JSON.stringify({ id: seq, method, params })); });
+  const once = (method, ms) => Promise.race([
+    new Promise(ok => waiters.set(method, ok)),
+    new Promise((_, ng) => setTimeout(() => ng(new Error(`timeout waiting for ${method}`)), ms)),
+  ]);
+  const goto = async (url) => {       // wait for the load event, not a fixed sleep
+    await call("Page.enable");
+    const loaded = once("Page.loadEventFired", 15000);
+    const nav = await call("Page.navigate", { url });
+    // Chromium "successfully" loads an error page on DNS/connect failures;
+    // the navigate response carries the real outcome in errorText.
+    if (nav.errorText) throw new Error(`navigation failed: ${nav.errorText}`);
+    await loaded;
+  };
+  const evaljs = async (expr) =>
+    (await call("Runtime.evaluate", { expression: expr, returnByValue: true })).result.value;
+
+  if (cmd === "goto") {
+    await goto(args[0]);
+    console.log("loaded:", await evaljs("location.href"));
+  } else if (cmd === "title") {
+    console.log(JSON.stringify(await evaljs("document.title")));
+  } else if (cmd === "eval") {
+    console.log(await evaljs(args[0]));
+  } else if (cmd === "shot") {
+    const { data } = await call("Page.captureScreenshot");
+    (await import("node:fs")).writeFileSync(args[0], Buffer.from(data, "base64"));
+    console.log(`saved: ${args[0]}`);
+  } else if (cmd === "smoke") {
+    const v = await j("/json/version");
+    console.log(`${process.env.NAME} (${ip}): ${v.Browser}`);
+    // Default to a live, constantly-changing page: a static page like
+    // example.com cannot show that real content is actually being fetched.
+    const url = args[0] ?? "https://www.yahoo.co.jp/";
+    try {
+      await goto(url);
+    } catch (e) {
+      // A freshly booted worker VM may drop the first request while its
+      // network settles (net::ERR_NETWORK_CHANGED). Retry once, visibly.
+      console.error(`first attempt failed (${e.message}), retrying once...`);
+      await new Promise(r => setTimeout(r, 2000));
+      await goto(url);
+    }
+    console.log("title:", JSON.stringify(await evaljs("document.title")));
+  } else {
+    console.error(usage);
+    process.exit(2);
+  }
+  ws.close();
+} catch (e) {
+  console.error("error:", e.message);
+  process.exit(1);
+}
+' -- "$IP" "$CMD" "$@"

--- a/docs-site/astro.config.ts
+++ b/docs-site/astro.config.ts
@@ -58,7 +58,8 @@ export default defineConfig({
           label: "Getting started",
           items: [
             { label: "Production (headless)", slug: "getting-started/production" },
-            { label: "Development (noVNC)", slug: "getting-started/development" },
+            { label: "Development (host + CDP)", slug: "getting-started/development" },
+            { label: "Verifying workers", slug: "getting-started/verify" },
           ],
         },
         {

--- a/docs-site/src/content/docs/getting-started/development.md
+++ b/docs-site/src/content/docs/getting-started/development.md
@@ -1,10 +1,10 @@
 ---
 title: Development (host + CDP)
-description: Develop on the macOS host and drive a debug-target Chromium container over CDP, watching it render via noVNC.
+description: Develop on the macOS host and drive a debug-target Chromium container over CDP, watching it render via noVNC or chrome://inspect.
 ---
 
-Development happens **on the host**: your editor, Node.js (puppeteer-core), and
-all other tooling run on macOS, while Chromium runs in a container built from
+Development happens **on the host**: your editor, Node.js, and all other
+tooling run on macOS, while Chromium runs in a container built from
 the `debug` target of the single multi-stage `docker/Dockerfile` — headful,
 with its virtual display served over VNC/noVNC so you can watch pages render.
 
@@ -15,7 +15,7 @@ so there is no host port mapping and no port offsets for a second worker.
 
 :::note
 All commands on this page assume you run them **from the repository root**
-(the build context is `.`, and `./bin/dev.sh` is invoked by relative path).
+(the build context is `.`, and the `bin/` helpers are invoked by relative path).
 
 The previous containerized development environment (Node.js, dotfiles,
 Claude Code, VS Code attach) is **mothballed** under `attic/development/`.
@@ -42,38 +42,15 @@ CDP  : http://192.168.64.x:9222/json/version
 noVNC: http://192.168.64.x:6080/vnc.html
 ```
 
-Manual equivalent:
-
-```sh
-container build --target debug -t chromium-server:debug -f docker/Dockerfile .
-container run -d --rm --cpus 4 --memory 4g --name chromium-debug chromium-server:debug
-container ls   # IP column
-```
-
 :::caution
 On the first connection macOS may ask for **Local Network** permission.
 Allow it for both the connecting app (terminal, browser) and the Container
 runtime; a missing grant surfaces as empty replies / hangs.
 :::
 
-## Drive it from the host
-
-Chromium is driven over CDP exactly as in production. With `puppeteer-core`
-on the host:
-
-```js
-const puppeteer = require('puppeteer-core');
-
-const browser = await puppeteer.connect({
-  browserURL: 'http://192.168.64.x:9222',
-});
-const page = await browser.newPage();
-await page.goto('https://example.com');
-```
-
 ## Watch it render
 
-Open the noVNC URL in a browser and press **Connect**:
+Open the noVNC URL printed by `./bin/dev.sh` and press **Connect**:
 
 ```text
 http://192.168.64.x:6080/vnc.html
@@ -81,6 +58,10 @@ http://192.168.64.x:6080/vnc.html
 
 You will see the headful Chromium window (with a fluxbox frame) executing
 whatever your CDP client does.
+
+For a zero-tooling alternative that also works for **headless** workers —
+the DevTools screencast via `chrome://inspect` — see
+[Verifying workers](/getting-started/verify/).
 
 ## Process management
 
@@ -90,12 +71,6 @@ whatever your CDP client does.
 ```sh
 container exec -it chromium-debug supervisorctl -c /etc/supervisor/conf.d/app.conf status
 container exec -it chromium-debug supervisorctl -c /etc/supervisor/conf.d/app.conf restart chromium
-```
-
-## Verify CDP
-
-```sh
-curl http://192.168.64.x:9222/json/version
 ```
 
 ## Next

--- a/docs-site/src/content/docs/getting-started/production.md
+++ b/docs-site/src/content/docs/getting-started/production.md
@@ -49,15 +49,6 @@ Chromium itself listens only on `127.0.0.1:9223`; `socat` bridges `:9222`
 to it. External CDP clients connect to port `9222` on the container IP. See
 [Chrome DevTools Protocol](/configuration/cdp/) for why, and how to verify.
 
-## Verify CDP
-
-```sh
-curl http://192.168.64.x:9222/json/version
-```
-
-A JSON payload with the Chromium build and the `webSocketDebuggerUrl` means
-CDP is reachable.
-
 ## Health and lifecycle
 
 The Dockerfile's `HEALTHCHECK` is honored by Docker-compatible runtimes

--- a/docs-site/src/content/docs/getting-started/verify.md
+++ b/docs-site/src/content/docs/getting-started/verify.md
@@ -1,0 +1,79 @@
+---
+title: Verifying workers
+description: One-shot CDP checks with bin/cdp.sh and live viewing via chrome://inspect — works identically for headless production and debug workers.
+---
+
+Every worker — the **headless `production` target and the headful `debug`
+target alike** — exposes the same CDP endpoint on `:9222` of its own IP, so
+the checks on this page work identically against both. Get the IP from the
+`./bin/prod.sh` / `./bin/dev.sh` output, or from `container ls`.
+
+:::note
+Commands assume the repository root. On the first connection macOS may ask
+for **Local Network** permission — allow it for both the connecting app
+(terminal, Chrome) and the Container runtime.
+:::
+
+## Quick checks — `bin/cdp.sh` (no scripts needed)
+
+```sh
+./bin/cdp.sh smoke                   # version + open a page + print its title
+```
+
+```text
+chromium-1 (192.168.64.x): Chrome/150.0.7871.100
+title: "Yahoo! JAPAN"
+```
+
+If that prints a title, the whole path — worker VM, socat, Chromium, CDP —
+is working. More one-shot commands:
+
+```sh
+./bin/cdp.sh goto https://www.wikipedia.org   # navigate (waits for load)
+./bin/cdp.sh title                            # print document.title
+./bin/cdp.sh eval 'location.href'             # evaluate any JS expression
+./bin/cdp.sh shot /tmp/page.png               # save a page screenshot (headless too)
+./bin/cdp.sh targets                          # list open tabs
+```
+
+The worker defaults to `chromium-debug`, then `chromium-1`; pick one
+explicitly with `CDP_TARGET=chromium-2 ./bin/cdp.sh ...`. Every failure
+exits non-zero, so the commands can back automated checks as-is.
+
+For an HTTP-only liveness probe (no WebSocket involved):
+
+```sh
+curl http://192.168.64.x:9222/json/version
+```
+
+## Watching rendering — chrome://inspect (zero tooling, headless too)
+
+Open `chrome://inspect/#devices` in the host Chrome, press **Configure…**
+and add the worker endpoint `192.168.64.x:9222`.
+
+The worker's tabs appear under **Remote Target**; click **inspect** to open
+DevTools with a **live screencast** of the page. This works for the
+**headless `production` target as well** — the new headless mode has a real
+renderer and compositor, so DevTools receives frames even though no display
+exists (measured: `Page.startScreencast` delivers frames from a headless
+worker). Navigate using the URL bar at the top of the screencast (or the
+Console), and use the full DevTools (Network, Elements, Console) as usual.
+
+:::caution
+If the endpoint is registered incorrectly (e.g. a **wrong port number**),
+there is no error — **nothing appears under Remote Target and no inspect
+link shows up**. The port is `9222`; check reachability with
+`curl http://<IP>:9222/json/version`. Worker IPs also change across
+restarts, so re-add the endpoint in **Configure…** after restarting a worker.
+
+Do not use the "Open tab with url" field on the inspect page: it relies on
+`/json/new?url=`, which on current Chromium creates an **empty tab without
+navigating** (measured). Navigate from the screencast URL bar instead.
+:::
+
+## Next
+
+- [Production (headless)](/getting-started/production/) — build and run
+  headless workers.
+- [Development (host + CDP)](/getting-started/development/) — the debug
+  target and watching it render via noVNC.

--- a/docs-site/src/content/docs/ja/getting-started/development.md
+++ b/docs-site/src/content/docs/ja/getting-started/development.md
@@ -1,9 +1,9 @@
 ---
 title: 開発（ホスト + CDP）
-description: macOS ホスト側で開発し、debug ターゲットの Chromium コンテナを CDP で駆動、noVNC で描画を観察する。
+description: macOS ホスト側で開発し、debug ターゲットの Chromium コンテナを CDP で駆動。noVNC や chrome://inspect で描画を観察する。
 ---
 
-開発は**ホスト側**で行います。エディタ・Node.js（puppeteer-core）などのツール一式は
+開発は**ホスト側**で行います。エディタ・Node.js などのツール一式は
 macOS 上で動かし、Chromium は単一 multi-stage `docker/Dockerfile` の `debug`
 ターゲットから作ったコンテナで動かします — headful で、仮想ディスプレイを
 VNC/noVNC 越しに観察できます。
@@ -15,7 +15,7 @@ VNC/noVNC 越しに観察できます。
 
 :::note
 このページのコマンドはすべて**リポジトリルートで実行**する前提です
-（ビルドコンテキストが `.` であり、`./bin/dev.sh` も相対パスで呼び出すため）。
+（ビルドコンテキストが `.` であり、`bin/` のヘルパも相対パスで呼び出すため）。
 
 以前の「コンテナ内完結」開発環境（Node.js・dotfiles・Claude Code・VS Code attach）は
 `attic/development/` に**凍結保管**しています。経緯と復活手順は
@@ -42,43 +42,25 @@ CDP  : http://192.168.64.x:9222/json/version
 noVNC: http://192.168.64.x:6080/vnc.html
 ```
 
-手動でやる場合:
-
-```sh
-container build --target debug -t chromium-server:debug -f docker/Dockerfile .
-container run -d --rm --cpus 4 --memory 4g --name chromium-debug chromium-server:debug
-container ls   # IP 列を参照
-```
-
 :::caution
 初回接続時に macOS が**ローカルネットワーク**権限を求めることがあります。
 接続元アプリ（ターミナル・ブラウザ）と Container ランタイムの**両方**を許可してください。
 許可漏れは empty reply やハングとして現れます。
 :::
 
-## ホストから駆動する
+## 目視で確認する
 
-Chromium の駆動方法は production と同じ CDP です。ホストの `puppeteer-core` から:
-
-```js
-const puppeteer = require('puppeteer-core');
-
-const browser = await puppeteer.connect({
-  browserURL: 'http://192.168.64.x:9222',
-});
-const page = await browser.newPage();
-await page.goto('https://example.com');
-```
-
-## 描画を観察する
-
-ブラウザで noVNC の URL を開き **Connect** を押します:
+`./bin/dev.sh` が表示した noVNC の URL を開き **Connect** を押します:
 
 ```text
 http://192.168.64.x:6080/vnc.html
 ```
 
 fluxbox の枠付き headful Chromium が、CDP クライアントの操作どおりに動く様子が見えます。
+
+ツール追加ゼロで **headless** worker にも使える代替手段 —
+`chrome://inspect` の DevTools スクリーンキャスト — は
+[worker の動作確認](/getting-started/verify/) を参照してください。
 
 ## プロセス管理
 
@@ -88,12 +70,6 @@ fluxbox の枠付き headful Chromium が、CDP クライアントの操作ど�
 ```sh
 container exec -it chromium-debug supervisorctl -c /etc/supervisor/conf.d/app.conf status
 container exec -it chromium-debug supervisorctl -c /etc/supervisor/conf.d/app.conf restart chromium
-```
-
-## CDP を確認する
-
-```sh
-curl http://192.168.64.x:9222/json/version
 ```
 
 ## 次のステップ

--- a/docs-site/src/content/docs/ja/getting-started/production.md
+++ b/docs-site/src/content/docs/ja/getting-started/production.md
@@ -49,15 +49,6 @@ Chromium 自体は `127.0.0.1:9223` だけを listen し、`socat` が `:9222` �
 橋渡しします。外部の CDP クライアントはコンテナ IP のポート `9222` に接続します。
 理由と確認方法は [Chrome DevTools Protocol](/ja/configuration/cdp/) を参照してください。
 
-## CDP を確認する
-
-```sh
-curl http://192.168.64.x:9222/json/version
-```
-
-Chromium のビルド情報と `webSocketDebuggerUrl` を含む JSON が返れば、
-CDP に到達できています。
-
 ## ヘルスとライフサイクル
 
 Dockerfile の `HEALTHCHECK` は Docker 互換ランタイム（CI の smoke ジョブ）では

--- a/docs-site/src/content/docs/ja/getting-started/verify.md
+++ b/docs-site/src/content/docs/ja/getting-started/verify.md
@@ -1,0 +1,81 @@
+---
+title: worker の動作確認
+description: bin/cdp.sh によるワンショット CDP 確認と、chrome://inspect によるライブ目視。headless の production と debug のどちらの worker にも同じ手順が使える。
+---
+
+worker は — **headless の `production` ターゲットも headful の `debug`
+ターゲットも** — 自分の IP の `:9222` に同じ CDP エンドポイントを公開して
+います。そのため、このページの確認手順はどちらの worker にも同じように
+使えます。IP は `./bin/prod.sh` / `./bin/dev.sh` の出力か `container ls`
+で確認してください。
+
+:::note
+コマンドはリポジトリルートで実行する前提です。初回接続時に macOS が
+**ローカルネットワーク**権限を求めることがあります — 接続元アプリ
+（ターミナル・Chrome）と Container ランタイムの両方を許可してください。
+:::
+
+## クイック確認 — `bin/cdp.sh`（スクリプト不要）
+
+```sh
+./bin/cdp.sh smoke                   # version 確認 + ページを開く + タイトル表示
+```
+
+```text
+chromium-1 (192.168.64.x): Chrome/150.0.7871.100
+title: "Yahoo! JAPAN"
+```
+
+タイトルが出れば、worker VM・socat・Chromium・CDP の経路すべてが機能しています。
+ほかのワンショットコマンド:
+
+```sh
+./bin/cdp.sh goto https://www.wikipedia.org   # ナビゲート（load 完了まで待つ）
+./bin/cdp.sh title                            # document.title を表示
+./bin/cdp.sh eval 'location.href'             # 任意の JS 式を評価
+./bin/cdp.sh shot /tmp/page.png               # スクリーンショット保存（headless でも可）
+./bin/cdp.sh targets                          # 開いているタブの一覧
+```
+
+対象 worker は `chromium-debug` → `chromium-1` の順で自動選択されます。
+明示するには `CDP_TARGET=chromium-2 ./bin/cdp.sh ...`。失敗はすべて
+exit≠0 になるため、そのまま自動チェックにも使えます。
+
+HTTP だけの生存確認（WebSocket を使わない最軽量プローブ）:
+
+```sh
+curl http://192.168.64.x:9222/json/version
+```
+
+## 目視で確認する — chrome://inspect（ツール追加ゼロ・headless でも映る）
+
+ホストの Chrome で `chrome://inspect/#devices` を開き、**Configure…** に
+worker のエンドポイント `192.168.64.x:9222` を追加します。
+
+**Remote Target** に worker のタブが並ぶので **inspect** をクリックすると、
+DevTools が開いて**スクリーンキャストに描画がライブ表示**されます。
+これは **headless の `production` ターゲットでも映ります** — 新 headless
+モードは本物のレンダラとコンポジタを持つため、画面が無くても DevTools に
+フレームが届きます（実測: headless worker から `Page.startScreencast` の
+フレーム受信を確認済み）。ページ移動はスクリーンキャスト上部の URL バー
+（または Console）で行い、Network・Elements・Console など DevTools 一式も
+そのまま使えます。
+
+:::caution
+エンドポイントの登録を間違えると（**ポート番号の誤り**など）、エラーは出ずに
+**Remote Target に何も表示されず、inspect リンクも現れません**。ポートは
+`9222` です。疎通は `curl http://<IP>:9222/json/version` で確認できます。
+また worker の IP は再起動ごとに変わるため、再起動後は **Configure…** への
+再登録が必要です。
+
+inspect ページの「Open tab with url」入力欄は使わないでください。
+`/json/new?url=` に依存しており、現行 Chromium では**空タブが増えるだけで
+ナビゲートしません**（実測）。ページ移動は必ずスクリーンキャストの URL バーで。
+:::
+
+## 次のステップ
+
+- [本番（headless）](/getting-started/production/) — headless worker の
+  build と run。
+- [開発（ホスト + CDP）](/getting-started/development/) — debug ターゲットと
+  noVNC による目視。


### PR DESCRIPTION
## 概要

動作確認のたびに puppeteer スクリプトを書く手間をなくします。①依存ゼロの CDP ヘルパ **`bin/cdp.sh`** を追加し、②動作確認のドキュメントを新設の **Verifying workers** ページ（en/ja）に一本化します。chrome://inspect の DevTools スクリーンキャストによる目視確認も手順化しました — **headless の production worker に対しても機能します**（実測）。

## bin/cdp.sh（依存ゼロ）

Node 22+ 内蔵の fetch/WebSocket だけで CDP を話します（npm install 不要）。

```console
% ./bin/cdp.sh smoke        # worker 解決 → version → ページを開く → タイトル表示
chromium-1 (192.168.64.x): Chrome/150.0.7871.100
title: "Yahoo! JAPAN"
```

- サブコマンド: `smoke` / `goto` / `title` / `eval` / `shot` / `targets`
- worker は `CDP_TARGET` 指定、未指定なら `chromium-debug → chromium-1 → chromium-*` を自動選択（IP 解決も自動）
- smoke の既定 URL は **yahoo.co.jp**（静的な example.com では実コンテンツ取得を示せないため）
- ナビゲーション失敗は `Page.navigate` の `errorText` で検出（Chromium はエラーページを"正常ロード"するため load 待ちだけでは検出不能）
- 起動直後 VM の `net::ERR_NETWORK_CHANGED` に対し smoke のみ可視リトライ 1 回
- 全失敗経路で exit≠0（自動チェックにそのまま流用可能）

## docs: 動作確認を verify ページへ一本化

- **新設** `getting-started/verify`（en/ja）: cdp.sh のクイック確認 + chrome://inspect の目視。production/development のどちらの worker にも同じ手順が使えることを明記
- chrome://inspect の実測注意を収録: **ポート番号を間違えるとエラーなしで inspect リンクが現れない** / 「Open tab with url」は `/json/new?url=` 依存でナビゲートしない / IP は再起動で変わる
- development / production から重複していた確認節を削除しリンクに置換。puppeteer-core 節は削除（本格自動化は BrowserHive の役割）
- サイドバーに verify を追加し、旧称のままだった "Development (noVNC)" ラベルを "Development (host + CDP)" に修正

## 動作確認（実測）

- debug / **headless production** 双方で `smoke` 成功（`title: "Yahoo! JAPAN"`）、`shot` は headless でも有効な PNG
- 到達不能 URL → `error: navigation failed: net::ERR_NAME_NOT_RESOLVED` で exit 1
- headless worker からの `Page.startScreencast` フレーム受信を実測（chrome://inspect が headless に効く根拠）
- `astro build` 成功（16 ページ、verify en/ja 含む）、shellcheck / hadolint / actionlint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
