### PR TITLE
docs(bin): record the measured memory rationale next to --memory 4g

### DIFF
--- a/bin/prod.sh
+++ b/bin/prod.sh
@@ -22,6 +22,8 @@ container build --target production -t chromium-server:production -f docker/Dock
 for i in $(seq 1 "${COUNT}"); do
     name="chromium-${i}"
     container stop "${name}" >/dev/null 2>&1 || true
+    # Apple Container VMs default to 1 GiB, which starves Chromium (measured:
+    # ~520 MiB with a single empty tab, before real page weight).
     container run -d --rm --cpus 4 --memory 4g --name "${name}" chromium-server:production
 done
 


### PR DESCRIPTION
## 概要

`bin/prod.sh` の `--memory 4g` の根拠（Apple Container の VM 既定 1 GiB では Chromium に不足 — 空タブ 1 枚で実測 約 520 MiB）を、フラグ直上のコメントとしてコードに記録します。これまで根拠は docs と凍結済みの dev.sh にしかなく、prod.sh 単体では「なぜ 4g か」が読めませんでした。

## 変更

- `bin/prod.sh`: `container run` の直上に実測コメント 2 行を追加（コメントのみ・挙動変更なし）

## 動作確認

- shellcheck 通過
- 回帰: `./bin/prod.sh` → `./bin/cdp.sh smoke` 成功（`title: "Yahoo! JAPAN"`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)