### PR TITLE
docs(verify): document the CDP Host-header rule (use IP, not hostname)

### DIFF
--- a/docs-site/src/content/docs/getting-started/verify.md
+++ b/docs-site/src/content/docs/getting-started/verify.md
@@ -47,7 +47,8 @@ curl http://192.168.64.x:9222/json/version
 ## Watching rendering — chrome://inspect (zero tooling, headless too)
 
 Open `chrome://inspect/#devices` in the host Chrome, press **Configure…**
-and add the worker endpoint `192.168.64.x:9222`.
+and add the worker endpoint `192.168.64.x:9222` — use the **IP**, not a
+hostname (see the caution below for why a name is silently rejected).
 
 The worker's tabs appear under **Remote Target**; click **inspect** to open
 DevTools with a **live screencast** of the page. This works for the
@@ -58,10 +59,19 @@ worker). Navigate using the URL bar at the top of the screencast (or the
 Console), and use the full DevTools (Network, Elements, Console) as usual.
 
 :::caution
-If the endpoint is registered incorrectly (e.g. a **wrong port number**),
-there is no error — **nothing appears under Remote Target and no inspect
-link shows up**. The port is `9222`; check reachability with
-`curl http://<IP>:9222/json/version`. Worker IPs also change across
+**Register the IP, not a hostname.** Chromium's CDP HTTP endpoint
+(`/json/*`) rejects any request whose `Host` header is not an IP address or
+`localhost` — a DNS-rebinding safeguard. So a hostname (a DNS / container
+service name such as `chromium-1`, even one that resolves) makes Chromium
+answer `Host header is specified and is not an IP address or localhost.`,
+and **nothing appears under Remote Target**. Only an IP (or `localhost`)
+works. As a bonus, `webSocketDebuggerUrl` is derived from that `Host`, so an
+IP request yields an IP-based ws URL the DevTools frontend can actually reach.
+
+If the endpoint is otherwise registered incorrectly (e.g. a **wrong port
+number**), there is likewise no error — **nothing appears under Remote
+Target and no inspect link shows up**. The port is `9222`; check reachability
+with `curl http://<IP>:9222/json/version`. Worker IPs also change across
 restarts, so re-add the endpoint in **Configure…** after restarting a worker.
 
 Do not use the "Open tab with url" field on the inspect page: it relies on

--- a/docs-site/src/content/docs/ja/getting-started/verify.md
+++ b/docs-site/src/content/docs/ja/getting-started/verify.md
@@ -47,7 +47,8 @@ curl http://192.168.64.x:9222/json/version
 ## 目視で確認する — chrome://inspect（ツール追加ゼロ・headless でも映る）
 
 ホストの Chrome で `chrome://inspect/#devices` を開き、**Configure…** に
-worker のエンドポイント `192.168.64.x:9222` を追加します。
+worker のエンドポイント `192.168.64.x:9222` を追加します。登録には必ず
+**IP** を使ってください（ホスト名では不可 — 理由は下の注意参照）。
 
 **Remote Target** に worker のタブが並ぶので **inspect** をクリックすると、
 DevTools が開いて**スクリーンキャストに描画がライブ表示**されます。
@@ -59,7 +60,18 @@ DevTools が開いて**スクリーンキャストに描画がライブ表示**�
 そのまま使えます。
 
 :::caution
-エンドポイントの登録を間違えると（**ポート番号の誤り**など）、エラーは出ずに
+**登録は IP で。ホスト名は不可。** Chromium の CDP エンドポイント
+（`/json/*`）は、リクエストの **`Host` ヘッダが「IP アドレス」でも
+「localhost」でもないと拒否**します（DNS リバインディング攻撃対策）。
+そのため、ホスト名（DNS/コンテナのサービス名。例 `chromium-1`。名前解決
+できるものでも）だと Chromium が
+`Host header is specified and is not an IP address or localhost.` を返し、
+**Remote Target に何も表示されません**。受理されるのは IP（または
+`localhost`）だけです。加えて `webSocketDebuggerUrl` はこの `Host` から
+生成されるため、IP で問い合わせれば DevTools が実際に届く IP ベースの
+ws URL が返る、という利点もあります。
+
+これ以外の登録ミス（**ポート番号の誤り**など）でも同様にエラーは出ず、
 **Remote Target に何も表示されず、inspect リンクも現れません**。ポートは
 `9222` です。疎通は `curl http://<IP>:9222/json/version` で確認できます。
 また worker の IP は再起動ごとに変わるため、再起動後は **Configure…** への


### PR DESCRIPTION
## Summary

`chrome://inspect` silently shows no targets when the endpoint is registered as a **hostname** instead of an IP — a real trap someone just hit. Chromium's CDP HTTP endpoint (`/json/*`) rejects any request whose `Host` header is not an IP address or `localhost` (a DNS-rebinding safeguard), answering `Host header is specified and is not an IP address or localhost.` A resolvable name (e.g. a container/DNS service name like `chromium-1`) still fails.

Adds this fact to `getting-started/verify` (EN + JA):
- the chrome://inspect instruction now says **use the IP, not a hostname**;
- the caution block explains the Host-header rule, quotes the exact error, and notes that `webSocketDebuggerUrl` is derived from the `Host` (so an IP request yields a reachable ws URL).

This matters because browserhive-style stacks expose workers by DNS name, which invites entering the name here.

Verified: `astro build` of docs-site passes (14 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ekt6mAyoTEkxwaKc3tPUQ