### PR TITLE
docs: localise the sidebar labels

### DIFF
--- a/docs-site/astro.config.ts
+++ b/docs-site/astro.config.ts
@@ -53,24 +53,53 @@ export default defineConfig({
         root: { label: "English", lang: "en" },
         ja: { label: "日本語", lang: "ja" },
       },
+      // Every entry carries a `ja` translation. Starlight localises pages but
+      // not navigation, so without these the Japanese docs are translated
+      // pages hanging off an English index.
       sidebar: [
         {
           label: "Getting started",
+          translations: { ja: "はじめに" },
           items: [
-            { label: "Production (headless)", slug: "getting-started/production" },
-            { label: "Verifying workers", slug: "getting-started/verify" },
+            {
+              label: "Production (headless)",
+              translations: { ja: "本番（headless）" },
+              slug: "getting-started/production",
+            },
+            {
+              label: "Verifying workers",
+              translations: { ja: "worker の動作確認" },
+              slug: "getting-started/verify",
+            },
           ],
         },
         {
           label: "Configuration",
+          translations: { ja: "設定" },
           items: [
-            { label: "Chromium flags", slug: "configuration/chromium-flags" },
-            { label: "Chrome DevTools Protocol", slug: "configuration/cdp" },
+            {
+              label: "Chromium flags",
+              translations: { ja: "Chromium フラグ" },
+              slug: "configuration/chromium-flags",
+            },
+            {
+              // The protocol's own name — not a phrase to translate.
+              label: "Chrome DevTools Protocol",
+              translations: { ja: "Chrome DevTools Protocol" },
+              slug: "configuration/cdp",
+            },
           ],
         },
         {
           label: "Internals",
-          items: [{ label: "Driving model & dbus", slug: "internals/driving-model" }],
+          translations: { ja: "内部構造" },
+          items: [
+            {
+              label: "Driving model & dbus",
+              translations: { ja: "駆動モデルと dbus" },
+              slug: "internals/driving-model",
+            },
+          ],
         },
       ],
     }),


### PR DESCRIPTION
Starlight はページを翻訳しますが**ナビゲーションは翻訳しません**。そのため日本語ドキュメントは、翻訳済みのページが英語の目次にぶら下がっている状態でした。

```
変更前:  Getting started | Configuration | Internals
変更後:  はじめに        | 設定          | 内部構造
```

全体はこうなります。

```
はじめに
  本番（headless） / worker の動作確認
設定
  Chromium フラグ / Chrome DevTools Protocol
内部構造
  駆動モデルと dbus
```

訳語は**各ページ自身のタイトル**から取っているので、ナビとページの表記が一致します。

`Chrome DevTools Protocol` だけは英語のままです ― プロトコルの固有名であって訳す語ではなく、日本語ページのタイトルも同じ表記だからです。

**英語版は無変更**（ビルド結果で確認済み）。

## この workspace で最後の 1 つ

同じ穴を今日 3 つ塞いでいます ― [browserhive 1.9.8](https://github.com/uraitakahito/browserhive/releases/tag/1.9.8) / [meadow v0.4.5](https://github.com/uraitakahito/meadow/releases/tag/v0.4.5) / [waggle 0.1.10](https://github.com/uraitakahito/waggle/releases/tag/0.1.10)。これで 4 サイトすべての日本語ドキュメントがナビゲーションまで日本語になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ekt6mAyoTEkxwaKc3tPUQ