### PR TITLE
release: v0.5.1

### DIFF
--- a/docs-site/astro.config.ts
+++ b/docs-site/astro.config.ts
@@ -53,24 +53,53 @@ export default defineConfig({
         root: { label: "English", lang: "en" },
         ja: { label: "日本語", lang: "ja" },
       },
+      // Every entry carries a `ja` translation. Starlight localises pages but
+      // not navigation, so without these the Japanese docs are translated
+      // pages hanging off an English index.
       sidebar: [
         {
           label: "Getting started",
+          translations: { ja: "はじめに" },
           items: [
-            { label: "Production (headless)", slug: "getting-started/production" },
-            { label: "Verifying workers", slug: "getting-started/verify" },
+            {
+              label: "Production (headless)",
+              translations: { ja: "本番（headless）" },
+              slug: "getting-started/production",
+            },
+            {
+              label: "Verifying workers",
+              translations: { ja: "worker の動作確認" },
+              slug: "getting-started/verify",
+            },
           ],
         },
         {
           label: "Configuration",
+          translations: { ja: "設定" },
           items: [
-            { label: "Chromium flags", slug: "configuration/chromium-flags" },
-            { label: "Chrome DevTools Protocol", slug: "configuration/cdp" },
+            {
+              label: "Chromium flags",
+              translations: { ja: "Chromium フラグ" },
+              slug: "configuration/chromium-flags",
+            },
+            {
+              // The protocol's own name — not a phrase to translate.
+              label: "Chrome DevTools Protocol",
+              translations: { ja: "Chrome DevTools Protocol" },
+              slug: "configuration/cdp",
+            },
           ],
         },
         {
           label: "Internals",
-          items: [{ label: "Driving model & dbus", slug: "internals/driving-model" }],
+          translations: { ja: "内部構造" },
+          items: [
+            {
+              label: "Driving model & dbus",
+              translations: { ja: "駆動モデルと dbus" },
+              slug: "internals/driving-model",
+            },
+          ],
         },
       ],
     }),


### PR DESCRIPTION
**このリリースからタグに `v` を付けます。** `npm version` の既定動作に合わせ、workspace 全体で統一するためです。過去のタグ（`0.4.0` 〜 `0.5.0`）は打ち直しません。

これで meadow / browserhive / waggle / waxlens / chromium-server-docker の 5 リポジトリすべてが `v` 付きに揃います。

## 中身

ドキュメントサイトの sidebar を日本語化しました。Starlight はページを翻訳しますがナビゲーションは翻訳しないため、日本語ページを開いても目次は英語のままでした。

```
はじめに
  本番（headless） / worker の動作確認
設定
  Chromium フラグ / Chrome DevTools Protocol
内部構造
  駆動モデルと dbus
```

同じ穴を他の 3 サイトでも塞いでおり、これが最後の 1 つです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ekt6mAyoTEkxwaKc3tPUQ